### PR TITLE
Remove GenAxisArray

### DIFF
--- a/src/ezmsg/util/generator.py
+++ b/src/ezmsg/util/generator.py
@@ -1,5 +1,4 @@
 import ezmsg.core as ez
-from ezmsg.util.messages.axisarray import AxisArray
 import traceback
 from typing import Any, AsyncGenerator, Generator, Callable, TypeVar
 from typing_extensions import ParamSpec
@@ -87,36 +86,3 @@ class Gen(ez.Unit):
             ez.logger.debug(f"Generator closed in {self.address}")
         except Exception:
             ez.logger.info(traceback.format_exc())
-
-
-class GenAxisArray(ez.Unit):
-    STATE: GenState
-
-    INPUT_SIGNAL = ez.InputStream(AxisArray)
-    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
-    INPUT_SETTINGS = ez.InputStream(ez.Settings)
-
-    def initialize(self) -> None:
-        self.construct_generator()
-
-    # Method to be implemented by subclasses to construct the specific generator
-    def construct_generator(self):
-        raise NotImplementedError
-
-    @ez.subscriber(INPUT_SETTINGS)
-    async def on_settings(self, msg: ez.Settings) -> None:
-        self.apply_settings(msg)
-        self.construct_generator()
-
-    @ez.subscriber(INPUT_SIGNAL)
-    @ez.publisher(OUTPUT_SIGNAL)
-    async def on_message(self, message: AxisArray) -> AsyncGenerator:
-        try:
-            ret = self.STATE.gen.send(message)
-            if ret is not None:
-                yield self.OUTPUT_SIGNAL, ret
-        except (StopIteration, GeneratorExit):
-            ez.logger.debug(f"Generator closed in {self.address}")
-        except Exception:
-            ez.logger.info(traceback.format_exc())
-

--- a/src/ezmsg/util/messages/modify.py
+++ b/src/ezmsg/util/messages/modify.py
@@ -1,11 +1,12 @@
 from dataclasses import replace
+import traceback
 import typing
 
 import numpy as np
 
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
-from ezmsg.util.generator import consumer, GenAxisArray
+from ezmsg.util.generator import consumer, GenState
 
 
 @consumer
@@ -31,8 +32,33 @@ class ModifyAxisSettings(ez.Settings):
     name_map: typing.Optional[typing.Dict[str, str]] = None
 
 
-class ModifyAxis(GenAxisArray):
+class ModifyAxis(ez.Unit):
+    STATE: GenState
     SETTINGS: ModifyAxisSettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+    INPUT_SETTINGS = ez.InputStream(ez.Settings)
+
+    def initialize(self) -> None:
+        self.construct_generator()
 
     def construct_generator(self):
         self.STATE.gen = modify_axis(name_map=self.SETTINGS.name_map)
+
+    @ez.subscriber(INPUT_SETTINGS)
+    async def on_settings(self, msg: ez.Settings) -> None:
+        self.apply_settings(msg)
+        self.construct_generator()
+
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def on_message(self, message: AxisArray) -> typing.AsyncGenerator:
+        try:
+            ret = self.STATE.gen.send(message)
+            if ret is not None:
+                yield self.OUTPUT_SIGNAL, ret
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"Generator closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())

--- a/tests/messages/test_modify.py
+++ b/tests/messages/test_modify.py
@@ -1,6 +1,8 @@
+import copy
+import typing
+
 import numpy as np
 import pytest
-import typing
 
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.messages.modify import modify_axis, ModifyAxis, ModifyAxisSettings
@@ -13,9 +15,19 @@ def test_modify_axis(name_map: typing.Optional[typing.Dict[str, str]]):
         dims=["step", "freq", "ch"],
         axes={"step": AxisArray.Axis.TimeAxis(fs=10.0, offset=0.0)},
     )
+    backup = copy.deepcopy(input_ax_arr)
 
     gen = modify_axis(name_map)
     res = gen.send(input_ax_arr)
+
+    # Make sure the input hasn't changed
+    assert np.array_equal(input_ax_arr.data, backup.data)
+    assert input_ax_arr.dims == backup.dims
+    assert list(input_ax_arr.axes.keys()) == list(backup.axes.keys())
+    for k, v in input_ax_arr.axes.items():
+        assert v == backup.axes[k]
+
+    assert res.data is input_ax_arr.data
     if name_map is None:
         assert res is input_ax_arr
     else:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -250,4 +250,4 @@ def test_gen_to_unit_axarr():
     assert len(results) == num_msgs
 
 
-# TODO: test compose, GenState, Gen, GenAxisArray
+# TODO: test compose, GenState, Gen


### PR DESCRIPTION
GenAxisArray was only being used by ezmsg-sigproc and one class in this repo: `ModifyAxis`. I changed the ModifyAxis code to do everything that GenAxisArray was doing then removed GenAxisArray. I reimplemented GenAxisArray in ezmsg-sigproc but there I made `zero_copy=True` though that PR should be merged before this PR is published on pypi.