### PR TITLE
fix: Settings and State assigned instead of annotated.

### DIFF
--- a/examples/ezmsg_configs.py
+++ b/examples/ezmsg_configs.py
@@ -14,7 +14,7 @@ class TerminatorSettings(ez.Settings):
 
 
 class Terminator(ez.Unit):
-    SETTINGS: TerminatorSettings
+    SETTINGS = TerminatorSettings
 
     @ez.task
     async def terminate(self) -> None:
@@ -31,7 +31,7 @@ class GeneratorSettings(ez.Settings):
 
 
 class Generator(ez.Unit):
-    SETTINGS: GeneratorSettings
+    SETTINGS = GeneratorSettings
 
     OUTPUT = ez.OutputStream(int)
 
@@ -51,7 +51,7 @@ class ModulusSettings(ez.Settings):
 
 
 class Modulus(ez.Unit):
-    SETTINGS: ModulusSettings
+    SETTINGS = ModulusSettings
 
     INPUT = ez.InputStream(int)
     OUTPUT = ez.OutputStream(int)
@@ -70,7 +70,7 @@ class ListenerState(ez.State):
 
 
 class Listener(ez.Unit):
-    STATE: ListenerState
+    STATE = ListenerState
 
     INPUT = ez.InputStream(int)
 

--- a/examples/ezmsg_count.py
+++ b/examples/ezmsg_count.py
@@ -20,7 +20,7 @@ class CountSettings(ez.Settings):
 
 
 class Count(ez.Unit):
-    SETTINGS: CountSettings
+    SETTINGS = CountSettings
 
     OUTPUT = ez.OutputStream(int)
 

--- a/examples/ezmsg_generator.py
+++ b/examples/ezmsg_generator.py
@@ -46,7 +46,7 @@ class PowSettings(ez.Settings):
 
 
 class Pow(Gen):
-    SETTINGS: PowSettings
+    SETTINGS = PowSettings
 
     def construct_generator(self):
         self.STATE.gen = pow(self.SETTINGS.n)
@@ -66,7 +66,7 @@ class AddSettings(ez.Settings):
 
 
 class Add(Gen):
-    SETTINGS: AddSettings
+    SETTINGS = AddSettings
 
     def construct_generator(self):
         self.STATE.gen = add(self.SETTINGS.n)

--- a/examples/ezmsg_intro.py
+++ b/examples/ezmsg_intro.py
@@ -61,7 +61,7 @@ class Count(ez.Unit):
     # We do this because this unit may receive settings objects
     # from parent collections.  Also, SETTINGS is a special/reserved
     # class attribute for Components (ez.Unit, and ez.Collection)
-    SETTINGS: CountSettings
+    SETTINGS = CountSettings
 
     OUTPUT_COUNT = ez.OutputStream(CountMessage)
 
@@ -115,7 +115,7 @@ class PrintState(ez.State):
 
 
 class PrintValue(ez.Unit):
-    SETTINGS: PrintSettings
+    SETTINGS = PrintSettings
 
     # As with settings, only provide a state type, do not instantiate.
     # We do this because this unit may end up living in a different
@@ -123,7 +123,7 @@ class PrintValue(ez.Unit):
     # pickled/sent to subprocesses (e.g. open file-handles, asyncio
     # and threading primitives, etc.) STATE is a special/reserved
     # class attribute for Units
-    STATE: PrintState
+    STATE = PrintState
 
     INPUT = ez.InputStream(CountMessage)
 
@@ -148,7 +148,7 @@ class CountSystemSettings(ez.Settings):
 
 
 class CountSystem(ez.Collection):
-    SETTINGS: CountSystemSettings
+    SETTINGS = CountSystemSettings
 
     # Define member units
     COUNT = Count()

--- a/examples/ezmsg_normalterm.py
+++ b/examples/ezmsg_normalterm.py
@@ -23,7 +23,7 @@ class MessageGeneratorSettings(ez.Settings):
 
 
 class MessageGenerator(ez.Unit):
-    SETTINGS: MessageGeneratorSettings
+    SETTINGS = MessageGeneratorSettings
 
     OUTPUT = ez.OutputStream(SimpleMessage)
 
@@ -47,8 +47,8 @@ class MessageReceiverState(ez.State):
 
 
 class MessageReceiver(ez.Unit):
-    STATE: MessageReceiverState
-    SETTINGS: MessageReceiverSettings
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
 
     INPUT = ez.InputStream(SimpleMessage)
 
@@ -71,7 +71,7 @@ class ToySystemSettings(ez.Settings):
 
 
 class ToySystem(ez.Collection):
-    SETTINGS: ToySystemSettings
+    SETTINGS = ToySystemSettings
 
     # Publishers
     SIMPLE_PUB = MessageGenerator()

--- a/examples/ezmsg_stop.py
+++ b/examples/ezmsg_stop.py
@@ -23,7 +23,7 @@ class MessageGeneratorSettings(ez.Settings):
 
 
 class MessageGenerator(ez.Unit):
-    SETTINGS: MessageGeneratorSettings
+    SETTINGS = MessageGeneratorSettings
 
     OUTPUT = ez.OutputStream(SimpleMessage)
 
@@ -47,8 +47,8 @@ class MessageReceiverState(ez.State):
 
 
 class MessageReceiver(ez.Unit):
-    STATE: MessageReceiverState
-    SETTINGS: MessageReceiverSettings
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
 
     INPUT = ez.InputStream(SimpleMessage)
 
@@ -71,7 +71,7 @@ class ToySystemSettings(ez.Settings):
 
 
 class ToySystem(ez.Collection):
-    SETTINGS: ToySystemSettings
+    SETTINGS = ToySystemSettings
 
     # Publishers
     SIMPLE_PUB = MessageGenerator()

--- a/examples/ezmsg_toy.py
+++ b/examples/ezmsg_toy.py
@@ -24,7 +24,7 @@ class LFOSettings(ez.Settings):
 
 
 class LFO(ez.Unit):
-    SETTINGS: LFOSettings
+    SETTINGS = LFOSettings
 
     OUTPUT = ez.OutputStream(float)
 
@@ -45,7 +45,7 @@ class MessageGeneratorSettings(ez.Settings):
 
 
 class MessageGenerator(ez.Unit):
-    SETTINGS: MessageGeneratorSettings
+    SETTINGS = MessageGeneratorSettings
 
     OUTPUT = ez.OutputStream(str)
 
@@ -68,7 +68,7 @@ class DebugOutputSettings(ez.Settings):
 
 
 class DebugOutput(ez.Unit):
-    SETTINGS: DebugOutputSettings
+    SETTINGS = DebugOutputSettings
 
     INPUT = ez.InputStream(str)
 
@@ -85,7 +85,7 @@ class MessageModifierState(ez.State):
 class MessageModifier(ez.Unit):
     """Store number input, and append it to message"""
 
-    STATE: MessageModifierState
+    STATE = MessageModifierState
 
     MESSAGE = ez.InputStream(str)
     NUMBER = ez.InputStream(float)
@@ -149,7 +149,7 @@ class TestSystemSettings(ez.Settings):
 
 
 class TestSystem(ez.Collection):
-    SETTINGS: TestSystemSettings
+    SETTINGS = TestSystemSettings
 
     # Publishers
     PING = MessageGenerator()

--- a/src/ezmsg/core/component.py
+++ b/src/ezmsg/core/component.py
@@ -25,13 +25,13 @@ class ComponentMeta(ABCMeta):
         if "SETTINGS" in cls.__annotations__:
             settings_cls = cls.__annotations__["SETTINGS"].__name__
             logger.warning(
-                f"{cls.__name__} SETTINGS should be assigned rather than annotated: `SETTINGS = {settings_cls}` -> `SETTINGS = {settings_cls}`"
+                f"{name} SETTINGS should be assigned rather than annotated: `SETTINGS = {settings_cls}` -> `SETTINGS = {settings_cls}`"
             )
             fields["SETTINGS"] = cls.__annotations__["SETTINGS"]
         if "STATE" in cls.__annotations__:
             state_cls = cls.__annotations__["STATE"].__name__
             logger.warning(
-                f"{cls.__name__} STATE should be assigned rather than annotated: `STATE = {state_cls}` -> `STATE = {state_cls}`"
+                f"{name} STATE should be assigned rather than annotated: `STATE = {state_cls}` -> `STATE = {state_cls}`"
             )
             fields["STATE"] = cls.__annotations__["STATE"]
 
@@ -56,26 +56,24 @@ class ComponentMeta(ABCMeta):
             if field_name == "SETTINGS":
                 if not issubclass(field_value, Settings):
                     logger.error(
-                        f"{cls.__name__} Settings must be a subclass of `ez.Settings`!"
+                        f"{name} Settings must be a subclass of `ez.Settings`!"
                     )
 
                 for settings_type in base_settings_types:
                     if not issubclass(field_value, settings_type):
                         logger.error(
-                            f"{cls.__name__} Settings of type {field_value.__name__} must be a subclass of {settings_type.__name__}"
+                            f"{name} Settings of type {field_value.__name__} must be a subclass of {settings_type.__name__}"
                         )
                 cls.__settings_type__ = field_value
 
             if field_name == "STATE":
                 if not issubclass(field_value, State):
-                    logger.error(
-                        f"{cls.__name__} State must be a subclass of `ez.State`!"
-                    )
+                    logger.error(f"{name} State must be a subclass of `ez.State`!")
 
                 for state_type in base_state_types:
                     if not issubclass(field_value, state_type):
                         logger.error(
-                            f"{cls.__name__} State of type {field_value.__name__} must be a subclass of {state_type.__name__}"
+                            f"{name} State of type {field_value.__name__} must be a subclass of {state_type.__name__}"
                         )
                 cls.__state_type__ = field_value
 

--- a/src/ezmsg/core/component.py
+++ b/src/ezmsg/core/component.py
@@ -46,7 +46,7 @@ class ComponentMeta(ABCMeta):
                     + f"but is trying to be set to {getattr(base, '__state_type__')}"
                 )
             if (
-                hasattr(base, "__state_type")
+                hasattr(base, "__state_type__")
                 and getattr(base, "__state_type__") is not State
             ):
                 cls.__state_type__ = getattr(base, "__state_type__")

--- a/src/ezmsg/core/settings.py
+++ b/src/ezmsg/core/settings.py
@@ -43,7 +43,7 @@ class Settings(ABC, metaclass=SettingsMeta):
 
        class YourUnit(Unit):
 
-          SETTINGS: YourSettings
+          SETTINGS = YourSettings
 
     A ``Unit`` can accept a ``Settings`` object as a parameter on instantiation.
 

--- a/src/ezmsg/core/state.py
+++ b/src/ezmsg/core/state.py
@@ -44,7 +44,7 @@ class State(ABC, metaclass=StateMeta):
 
        class YourUnit(Unit):
 
-          STATE: YourState
+          STATE = YourState
 
           def initialize(self):
              this.STATE.state1 = 0

--- a/src/ezmsg/util/debuglog.py
+++ b/src/ezmsg/util/debuglog.py
@@ -22,7 +22,7 @@ class DebugLog(ez.Unit):
     Logs messages that pass through.
     """
 
-    SETTINGS: DebugLogSettings
+    SETTINGS = DebugLogSettings
 
     INPUT = ez.InputStream(Any)
     """Send messages to log here."""

--- a/src/ezmsg/util/generator.py
+++ b/src/ezmsg/util/generator.py
@@ -61,7 +61,7 @@ class GenState(ez.State):
 
 # Abstract Unit class that uses a generator for processing messages
 class Gen(ez.Unit):
-    STATE: GenState
+    STATE = GenState
 
     INPUT = ez.InputStream(Any)
     OUTPUT = ez.OutputStream(Any)

--- a/src/ezmsg/util/messagegate.py
+++ b/src/ezmsg/util/messagegate.py
@@ -37,8 +37,8 @@ class MessageGate(ez.Unit):
     Can be set as open, closed, open after n messages, or closed after n messages.
     """
 
-    SETTINGS: MessageGateSettings
-    STATE: MessageGateState
+    SETTINGS = MessageGateSettings
+    STATE = MessageGateState
 
     INPUT_GATE = ez.InputStream(GateMessage)
     """

--- a/src/ezmsg/util/messagelogger.py
+++ b/src/ezmsg/util/messagelogger.py
@@ -38,8 +38,8 @@ class MessageLogger(ez.Unit):
     :py:class:`pathlib.Path` to ``INPUT_START``.
     """
 
-    SETTINGS: MessageLoggerSettings
-    STATE: MessageLoggerState
+    SETTINGS = MessageLoggerSettings
+    STATE = MessageLoggerState
 
     INPUT_START = ez.InputStream(Path)
     """

--- a/src/ezmsg/util/messagequeue.py
+++ b/src/ezmsg/util/messagequeue.py
@@ -28,8 +28,8 @@ class MessageQueue(ez.Unit):
     Place between two other ``Units`` to induce backpressure.
     """
 
-    SETTINGS: MessageQueueSettings
-    STATE: MessageQueueState
+    SETTINGS = MessageQueueSettings
+    STATE = MessageQueueState
 
     INPUT = ez.InputStream(Any)
     """Send messages to queue here."""

--- a/src/ezmsg/util/messagereplay.py
+++ b/src/ezmsg/util/messagereplay.py
@@ -65,8 +65,8 @@ class MessageReplay(ez.Unit):
     Stores a queue of files to stream and streams from them in order.
     """
 
-    SETTINGS: MessageReplaySettings
-    STATE: MessageReplayState
+    SETTINGS = MessageReplaySettings
+    STATE = MessageReplayState
 
     INPUT_FILE = ez.InputStream(FileReplayMessage)
     """Add a new file to the queue."""
@@ -213,7 +213,7 @@ class MessageCollector(ez.Unit):
     Collects ``Messages`` into a local list.
     """
 
-    STATE: MessageCollectorState
+    STATE = MessageCollectorState
 
     INPUT_MESSAGE = ez.InputStream(typing.Any)
     """Send messages here to be collected."""

--- a/src/ezmsg/util/messages/modify.py
+++ b/src/ezmsg/util/messages/modify.py
@@ -33,8 +33,8 @@ class ModifyAxisSettings(ez.Settings):
 
 
 class ModifyAxis(ez.Unit):
-    STATE: GenState
-    SETTINGS: ModifyAxisSettings
+    STATE = GenState
+    SETTINGS = ModifyAxisSettings
 
     INPUT_SIGNAL = ez.InputStream(AxisArray)
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)

--- a/src/ezmsg/util/terminate.py
+++ b/src/ezmsg/util/terminate.py
@@ -29,8 +29,8 @@ class TerminateOnTimeout(ez.Unit):
     End a pipeline execution when a certain amount of time has passed without receiving a message.
     """
 
-    SETTINGS: TerminateOnTimeoutSettings
-    STATE: TerminateOnTimeoutState
+    SETTINGS = TerminateOnTimeoutSettings
+    STATE = TerminateOnTimeoutState
 
     INPUT = ez.InputStream(Any)
     """Send messages here."""
@@ -71,8 +71,8 @@ class TerminateOnTotal(ez.Unit):
     End a pipeline execution once a certain number of messages have been received.
     """
 
-    SETTINGS: TerminateOnTotalSettings
-    STATE: TerminateOnTotalState
+    SETTINGS = TerminateOnTotalSettings
+    STATE = TerminateOnTotalState
 
     INPUT_MESSAGE = ez.InputStream(Any)
     """Send messages here."""

--- a/tests/ez_test_utils.py
+++ b/tests/ez_test_utils.py
@@ -41,7 +41,7 @@ class MessageGeneratorSettings(ez.Settings):
 
 
 class MessageGenerator(ez.Unit):
-    SETTINGS: MessageGeneratorSettings
+    SETTINGS = MessageGeneratorSettings
 
     OUTPUT = ez.OutputStream(SimpleMessage)
 
@@ -63,8 +63,8 @@ class MessageReceiverState(ez.State):
 
 
 class MessageReceiver(ez.Unit):
-    STATE: MessageReceiverState
-    SETTINGS: MessageReceiverSettings
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
 
     INPUT = ez.InputStream(SimpleMessage)
 

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -17,8 +17,8 @@ class TransmitReceiveState(ez.State):
 
 
 class TransmitReceive(ez.Unit):
-    SETTINGS: TransmitReceiveSettings
-    STATE: TransmitReceiveState
+    SETTINGS = TransmitReceiveSettings
+    STATE = TransmitReceiveState
 
     OUTPUT = ez.OutputStream(str)
     INPUT = ez.InputStream(str)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -139,8 +139,8 @@ def test_gen_funcs():
 
 
 class MessageAnyReceiver(ez.Unit):
-    STATE: MessageReceiverState
-    SETTINGS: MessageReceiverSettings
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
 
     INPUT = ez.InputStream(typing.List[typing.Any])
 
@@ -191,7 +191,7 @@ def test_gen_to_unit_any():
 
 
 class AxarrGenerator(ez.Unit):
-    SETTINGS: MessageGeneratorSettings
+    SETTINGS = MessageGeneratorSettings
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
 
     @ez.publisher(OUTPUT_SIGNAL)
@@ -202,8 +202,8 @@ class AxarrGenerator(ez.Unit):
 
 
 class AxarrReceiver(ez.Unit):
-    STATE: MessageReceiverState
-    SETTINGS: MessageReceiverSettings
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
     INPUT_SIGNAL = ez.InputStream(AxisArray)
 
     @ez.subscriber(INPUT_SIGNAL)

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -49,7 +49,7 @@ class LoadTestSample:
 
 class LoadTestPublisher(ez.Unit):
     OUTPUT = ez.OutputStream(LoadTestSample)
-    SETTINGS: LoadTestSettings
+    SETTINGS = LoadTestSettings
 
     def initialize(self) -> None:
         self.running = True
@@ -91,8 +91,8 @@ class LoadTestSubscriberState(ez.State):
 
 class LoadTestSubscriber(ez.Unit):
     INPUT = ez.InputStream(LoadTestSample)
-    SETTINGS: LoadTestSettings
-    STATE: LoadTestSubscriberState
+    SETTINGS = LoadTestSettings
+    STATE = LoadTestSubscriberState
 
     @ez.subscriber(INPUT, zero_copy=True)
     async def receive(self, sample: LoadTestSample) -> None:
@@ -111,7 +111,7 @@ class LoadTestSubscriber(ez.Unit):
 
         # Wait for the duration of the load test
         await asyncio.sleep(self.SETTINGS.duration)
-        # logger.info(f"STATE: {self.STATE.received_data}")
+        # logger.info(f"STATE = {self.STATE.received_data}")
 
         # Log some useful summary statistics
         min_timestamp = min(timestamp for timestamp, _, _ in self.STATE.received_data)
@@ -148,7 +148,7 @@ class LoadTestSubscriber(ez.Unit):
 
 
 class LoadTest(ez.Collection):
-    SETTINGS: LoadTestSettings
+    SETTINGS = LoadTestSettings
 
     PUBLISHER = LoadTestPublisher()
     SUBSCRIBER = LoadTestSubscriber()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,7 @@ class ToySystemSettings(ez.Settings):
 
 
 class ToySystem(ez.Collection):
-    SETTINGS: ToySystemSettings
+    SETTINGS = ToySystemSettings
 
     # Publishers
     SIMPLE_PUB = MessageGenerator()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -24,8 +24,8 @@ class ToySettings(ez.Settings):
 
 
 class ToyUnit(ez.Unit):
-    STATE: ToyState
-    SETTINGS: ToySettings
+    STATE = ToyState
+    SETTINGS = ToySettings
 
     def initialize(self) -> None:
         if self.SETTINGS.override_integer is not None:


### PR DESCRIPTION
This PR was orginally intended to simply fix https://github.com/ezmsg-org/ezmsg/issues/134, but I believe this is a good time to refactor the specification of `SETTINGS` and `STATE` in a `Component` to be more pythonic. Thus, this PR enables and encourages the declaration of `SETTINGS` and `STATE` via assignment rather than by annotation. The annotation approach will not be deprecated immediately, but will emit a logging warning to notify the end-user of this design change.

This fixes static type-check errors introduced by annotating.

You may run the following command to fix downstream codebases using the `find` and `sed` tools:

```bash
find . -type f -name "*.py" -exec sed -i 's/SETTINGS:/SETTINGS =/g' {} +
find . -type f -name "*.py" -exec sed -i 's/STATE:/STATE =/g' {} +
```