### PR TITLE
Add `array_chunker` to iterate over chunks of arbitrary npt.ArrayLike objects

### DIFF
--- a/src/ezmsg/util/messages/chunker.py
+++ b/src/ezmsg/util/messages/chunker.py
@@ -1,0 +1,99 @@
+import asyncio
+from dataclasses import replace
+import traceback
+import typing
+
+import numpy as np
+import numpy.typing as npt
+
+import ezmsg.core as ez
+from .axisarray import AxisArray, slice_along_axis
+from ..generator import GenState
+
+
+def array_chunker(
+    data: npt.ArrayLike,
+    chunk_len: int,
+    axis: int = 0,
+    fs: float = 1000.0,
+    tzero: float = 0.0,
+) -> typing.Generator[AxisArray, None, None]:
+    """
+    Create a generator that yields chunks of an array along a specified axis.
+    The generator should be useful for quick offline analyses, tests, or examples.
+    This generator probably is not useful for online streaming applications.
+
+    Parameters:
+        data: An array_like object to iterate over, chunk-by-chunk.
+        chunk_len: The length of the chunk returned in each iteration (except the last).
+        axis: The axis along which to chunk the array.
+        fs: The sampling frequency of the data. Will only be used to make the time axis.
+        tzero: The time offset of the first chunk. Will only be used to make the time axis.
+
+    Returns:
+        A generator that yields AxisArrays containing chunks of the input array.
+    """
+
+    if not type(data) == np.ndarray:
+        data = np.array(data)
+    n_chunks = int(np.ceil(data.shape[axis] / chunk_len))
+    tvec = np.arange(n_chunks, dtype=float) * chunk_len / fs + tzero
+    out_dims = [f"d{_}" for _ in range(data.ndim)]
+    out_dims[axis] = "time"
+    template = AxisArray(
+        slice_along_axis(data, slice(None, 0), axis),
+        dims=out_dims,
+        axes={"time": AxisArray.Axis.TimeAxis(fs=fs, offset=tvec[0])}
+    )
+
+    for chunk_ix in range(n_chunks):
+        view = slice_along_axis(data, slice(chunk_ix*chunk_len, (chunk_ix+1)*chunk_len), axis)
+        axis_arr_out = replace(
+            template,
+            data=view,
+            axes={"time": AxisArray.Axis.TimeAxis(fs=fs, offset=tvec[chunk_ix])}
+        )
+        yield axis_arr_out
+
+
+class ArrayChunkerSettings(ez.Settings):
+    data: npt.ArrayLike
+    chunk_len: int
+    axis: int = 0
+    fs: float = 1000.0
+    tzero: float = 0.0
+
+
+class ArrayChunker(ez.Unit):
+    SETTINGS = ArrayChunkerSettings
+    STATE = GenState
+
+    OUTPUT_SIGNAL = ez.OutputStream(typing.Any)
+    INPUT_SETTINGS = ez.InputStream(ArrayChunkerSettings)
+
+    async def initialize(self) -> None:
+        self.construct_generator()
+
+    def construct_generator(self):
+        self.STATE.gen = array_chunker(
+            data=self.SETTINGS.data,
+            chunk_len=self.SETTINGS.chunk_len,
+            axis=self.SETTINGS.axis,
+            fs=self.SETTINGS.fs,
+            tzero=self.SETTINGS.tzero
+        )
+
+    @ez.subscriber(INPUT_SETTINGS)
+    async def on_settings(self, msg: ez.Settings) -> None:
+        self.apply_settings(msg)
+        self.construct_generator()
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def send_chunk(self) -> typing.AsyncGenerator:
+        try:
+            yield self.OUTPUT_SIGNAL, next(self.STATE.gen)
+            await asyncio.sleep(0)
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"MessageSender closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())

--- a/src/ezmsg/util/messages/modify.py
+++ b/src/ezmsg/util/messages/modify.py
@@ -5,8 +5,8 @@ import typing
 import numpy as np
 
 import ezmsg.core as ez
-from ezmsg.util.messages.axisarray import AxisArray
-from ezmsg.util.generator import consumer, GenState
+from .axisarray import AxisArray
+from ..generator import consumer, GenState
 
 
 @consumer
@@ -64,7 +64,7 @@ class ModifyAxis(ez.Unit):
 
     INPUT_SIGNAL = ez.InputStream(AxisArray)
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
-    INPUT_SETTINGS = ez.InputStream(ez.Settings)
+    INPUT_SETTINGS = ez.InputStream(ModifyAxisSettings)
 
     async def initialize(self) -> None:
         self.construct_generator()
@@ -85,6 +85,6 @@ class ModifyAxis(ez.Unit):
             if ret is not None:
                 yield self.OUTPUT_SIGNAL, ret
         except (StopIteration, GeneratorExit):
-            ez.logger.debug(f"Generator closed in {self.address}")
+            ez.logger.debug(f"ModifyAxis closed in {self.address}")
         except Exception:
             ez.logger.info(traceback.format_exc())

--- a/tests/messages/test_chunker.py
+++ b/tests/messages/test_chunker.py
@@ -1,0 +1,31 @@
+import time
+import pytest
+
+import numpy as np
+
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.chunker import array_chunker
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_array_chunker(axis: int):
+    tzero = time.time()
+    dshape = [3, 4, 5]
+    dshape[axis] = 10_000
+    dshape = tuple(dshape)
+    fs = 1_000.0
+    chunk_len = 19
+    data = np.arange(np.prod(dshape)).reshape(dshape)
+    tvec = np.arange(dshape[axis]) / fs + tzero
+
+    chunker = array_chunker(data, chunk_len=chunk_len, axis=axis, fs=fs, tzero=tzero)
+    chunks = list(chunker)
+
+    assert len(chunks) == int(np.ceil(dshape[axis] / chunk_len))
+    assert all(isinstance(chunk, AxisArray) for chunk in chunks)
+    assert all(chunk.data.ndim == data.ndim for chunk in chunks)
+    assert all(chunk.data.shape[axis] == chunk_len for chunk in chunks[:-1])
+    assert chunks[-1].data.shape[axis] == dshape[axis] % chunk_len
+    assert np.array_equal([_.axes["time"].offset for _ in chunks], tvec[::chunk_len])
+    assert np.array_equal(np.concatenate([chunk.data for chunk in chunks], axis=axis), data)
+    assert all(np.may_share_memory(chunk.data, data) for chunk in chunks)


### PR DESCRIPTION
This is useful for tests, examples, and quick offline analyses with small'ish datasets.
