### PR TITLE
Add `key` field to AxisArray structure, with a Unit to set the key and another to filter on key

### DIFF
--- a/src/ezmsg/util/messages/chunker.py
+++ b/src/ezmsg/util/messages/chunker.py
@@ -1,0 +1,99 @@
+import asyncio
+from dataclasses import replace
+import traceback
+import typing
+
+import numpy as np
+import numpy.typing as npt
+
+import ezmsg.core as ez
+from .axisarray import AxisArray, slice_along_axis
+from ..generator import GenState
+
+
+def array_chunker(
+    data: npt.ArrayLike,
+    chunk_len: int,
+    axis: int = 0,
+    fs: float = 1000.0,
+    tzero: float = 0.0,
+) -> typing.Generator[AxisArray, None, None]:
+    """
+    Create a generator that yields chunks of an array along a specified axis.
+    The generator should be useful for quick offline analyses, tests, or examples.
+    This generator probably is not useful for online streaming applications.
+
+    Parameters:
+        data: An array_like object to iterate over, chunk-by-chunk.
+        chunk_len: The length of the chunk returned in each iteration (except the last).
+        axis: The axis along which to chunk the array.
+        fs: The sampling frequency of the data. Will only be used to make the time axis.
+        tzero: The time offset of the first chunk. Will only be used to make the time axis.
+
+    Returns:
+        A generator that yields AxisArrays containing chunks of the input array.
+    """
+
+    if not type(data) == np.ndarray:
+        data = np.array(data)
+    n_chunks = int(np.ceil(data.shape[axis] / chunk_len))
+    tvec = np.arange(n_chunks, dtype=float) * chunk_len / fs + tzero
+    out_dims = [f"d{_}" for _ in range(data.ndim)]
+    out_dims[axis] = "time"
+    template = AxisArray(
+        slice_along_axis(data, slice(None, 0), axis),
+        dims=out_dims,
+        axes={"time": AxisArray.Axis.TimeAxis(fs=fs, offset=tvec[0])}
+    )
+
+    for chunk_ix in range(n_chunks):
+        view = slice_along_axis(data, slice(chunk_ix*chunk_len, (chunk_ix+1)*chunk_len), axis)
+        axis_arr_out = replace(
+            template,
+            data=view,
+            axes={"time": AxisArray.Axis.TimeAxis(fs=fs, offset=tvec[chunk_ix])}
+        )
+        yield axis_arr_out
+
+
+class ArrayChunkerSettings(ez.Settings):
+    data: npt.ArrayLike
+    chunk_len: int
+    axis: int = 0
+    fs: float = 1000.0
+    tzero: float = 0.0
+
+
+class ArrayChunker(ez.Unit):
+    SETTINGS = ArrayChunkerSettings
+    STATE = GenState
+
+    OUTPUT_SIGNAL = ez.OutputStream(typing.Any)
+    INPUT_SETTINGS = ez.InputStream(ArrayChunkerSettings)
+
+    async def initialize(self) -> None:
+        self.construct_generator()
+
+    def construct_generator(self):
+        self.STATE.gen = array_chunker(
+            data=self.SETTINGS.data,
+            chunk_len=self.SETTINGS.chunk_len,
+            axis=self.SETTINGS.axis,
+            fs=self.SETTINGS.fs,
+            tzero=self.SETTINGS.tzero
+        )
+
+    @ez.subscriber(INPUT_SETTINGS)
+    async def on_settings(self, msg: ez.Settings) -> None:
+        self.apply_settings(msg)
+        self.construct_generator()
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def send_chunk(self) -> typing.AsyncGenerator:
+        try:
+            yield self.OUTPUT_SIGNAL, next(self.STATE.gen)
+            await asyncio.sleep(0)
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"MessageSender closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())

--- a/src/ezmsg/util/messages/chunker.py
+++ b/src/ezmsg/util/messages/chunker.py
@@ -68,8 +68,8 @@ class ArrayChunker(ez.Unit):
     SETTINGS = ArrayChunkerSettings
     STATE = GenState
 
-    OUTPUT_SIGNAL = ez.OutputStream(typing.Any)
     INPUT_SETTINGS = ez.InputStream(ArrayChunkerSettings)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
 
     async def initialize(self) -> None:
         self.construct_generator()
@@ -91,9 +91,10 @@ class ArrayChunker(ez.Unit):
     @ez.publisher(OUTPUT_SIGNAL)
     async def send_chunk(self) -> typing.AsyncGenerator:
         try:
-            yield self.OUTPUT_SIGNAL, next(self.STATE.gen)
-            await asyncio.sleep(0)
+            while True:
+                yield self.OUTPUT_SIGNAL, next(self.STATE.gen)
+                await asyncio.sleep(0)
         except (StopIteration, GeneratorExit):
-            ez.logger.debug(f"MessageSender closed in {self.address}")
+            ez.logger.debug(f"ArrayChunker closed in {self.address}")
         except Exception:
             ez.logger.info(traceback.format_exc())

--- a/src/ezmsg/util/messages/key.py
+++ b/src/ezmsg/util/messages/key.py
@@ -1,0 +1,89 @@
+from dataclasses import replace
+import traceback
+import typing
+
+import numpy as np
+
+import ezmsg.core as ez
+from .axisarray import AxisArray
+from ..generator import consumer, GenState
+
+
+@consumer
+def set_key(
+    key: str = ""
+) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Set the key of an AxisArray.
+
+    Args:
+        key: The string to set as the key.
+
+    Returns:
+        A primed generator object ready to yield an AxisArray with the key set for each .send(axis_array)
+    """
+    # State variables
+    axis_arr_in = AxisArray(np.array([]), dims=[""])
+    axis_arr_out = AxisArray(np.array([]), dims=[""])
+
+    while True:
+        axis_arr_in = yield axis_arr_out
+
+        axis_arr_out = replace(axis_arr_in, key=key)
+
+
+class KeySettings(ez.Settings):
+    key: str = ""
+
+
+class SetKey(ez.Unit):
+    STATE = GenState
+    SETTINGS = KeySettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+    INPUT_SETTINGS = ez.InputStream(ez.Settings)
+
+    async def initialize(self) -> None:
+        self.construct_generator()
+
+    def construct_generator(self):
+        self.STATE.gen = set_key(key=self.SETTINGS.key)
+
+    @ez.subscriber(INPUT_SETTINGS)
+    async def on_settings(self, msg: ez.Settings) -> None:
+        self.apply_settings(msg)
+        self.construct_generator()
+
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def on_message(self, message: AxisArray) -> typing.AsyncGenerator:
+        try:
+            ret = self.STATE.gen.send(message)
+            if ret is not None:
+                yield self.OUTPUT_SIGNAL, ret
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"SetKey closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())
+
+
+class FilterOnKey(ez.Unit):
+    """
+    Filter an AxisArray based on its key.
+    Note: There is no associated generator method for this Unit because messages that fail the filter
+     would still be yielded (as None), which complicates downstream processing. For contexts where filtering
+     on key is desired but the ezmsg framework is not used, use normal Python functional programming.
+     See https://github.com/ezmsg-org/ezmsg/issues/142#issuecomment-2323110318
+    """
+    SETTINGS = KeySettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def on_message(self, message: AxisArray) -> typing.AsyncGenerator:
+        if message.key == self.SETTINGS.key:
+            out = replace(message, key=message.key)  # Minimal 'touch' to prevent deepcopy by framework
+            yield self.OUTPUT_SIGNAL, out

--- a/src/ezmsg/util/messages/modify.py
+++ b/src/ezmsg/util/messages/modify.py
@@ -5,8 +5,8 @@ import typing
 import numpy as np
 
 import ezmsg.core as ez
-from ezmsg.util.messages.axisarray import AxisArray
-from ezmsg.util.generator import consumer, GenState
+from .axisarray import AxisArray
+from ..generator import consumer, GenState
 
 
 @consumer
@@ -64,7 +64,7 @@ class ModifyAxis(ez.Unit):
 
     INPUT_SIGNAL = ez.InputStream(AxisArray)
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
-    INPUT_SETTINGS = ez.InputStream(ez.Settings)
+    INPUT_SETTINGS = ez.InputStream(ModifyAxisSettings)
 
     async def initialize(self) -> None:
         self.construct_generator()
@@ -85,6 +85,6 @@ class ModifyAxis(ez.Unit):
             if ret is not None:
                 yield self.OUTPUT_SIGNAL, ret
         except (StopIteration, GeneratorExit):
-            ez.logger.debug(f"Generator closed in {self.address}")
+            ez.logger.debug(f"ModifyAxis closed in {self.address}")
         except Exception:
             ez.logger.info(traceback.format_exc())

--- a/tests/messages/test_chunker.py
+++ b/tests/messages/test_chunker.py
@@ -1,0 +1,31 @@
+import time
+import pytest
+
+import numpy as np
+
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.chunker import array_chunker
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_array_chunker(axis: int):
+    tzero = time.time()
+    dshape = [3, 4, 5]
+    dshape[axis] = 10_000
+    dshape = tuple(dshape)
+    fs = 1_000.0
+    chunk_len = 19
+    data = np.arange(np.prod(dshape)).reshape(dshape)
+    tvec = np.arange(dshape[axis]) / fs + tzero
+
+    chunker = array_chunker(data, chunk_len=chunk_len, axis=axis, fs=fs, tzero=tzero)
+    chunks = list(chunker)
+
+    assert len(chunks) == int(np.ceil(dshape[axis] / chunk_len))
+    assert all(isinstance(chunk, AxisArray) for chunk in chunks)
+    assert all(chunk.data.ndim == data.ndim for chunk in chunks)
+    assert all(chunk.data.shape[axis] == chunk_len for chunk in chunks[:-1])
+    assert chunks[-1].data.shape[axis] == dshape[axis] % chunk_len
+    assert np.array_equal([_.axes["time"].offset for _ in chunks], tvec[::chunk_len])
+    assert np.array_equal(np.concatenate([chunk.data for chunk in chunks], axis=axis), data)
+    assert all(np.may_share_memory(chunk.data, data) for chunk in chunks)

--- a/tests/messages/test_key.py
+++ b/tests/messages/test_key.py
@@ -1,0 +1,134 @@
+import copy
+import json
+import os
+import typing
+
+import numpy as np
+
+import ezmsg.core as ez
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.key import set_key, SetKey, FilterOnKey
+from ..ez_test_utils import (
+    get_test_fn,
+    MessageGeneratorSettings,
+    MessageReceiverSettings,
+    MessageReceiverState,
+)
+
+
+def test_set_key():
+    input_ax_arr = AxisArray(
+        data=np.arange(60).reshape(3, 5, 4),
+        dims=["step", "freq", "ch"],
+        axes={"step": AxisArray.Axis.TimeAxis(fs=10.0, offset=0.0)},
+        key="old key"
+    )
+    backup = copy.deepcopy(input_ax_arr)
+
+    gen = set_key(key="new key")
+    res = gen.send(input_ax_arr)
+
+    # Make sure the input hasn't changed
+    assert np.array_equal(input_ax_arr.data, backup.data)
+    assert input_ax_arr.dims == backup.dims
+    assert list(input_ax_arr.axes.keys()) == list(backup.axes.keys())
+    for k, v in input_ax_arr.axes.items():
+        assert v == backup.axes[k]
+
+    # We don't want the data to be copied
+    assert res.data is input_ax_arr.data
+
+    assert res.key == "new key"
+
+
+class KeyedAxarrGenerator(ez.Unit):
+    SETTINGS = MessageGeneratorSettings
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def spawn(self) -> typing.AsyncGenerator:
+        for i in range(self.SETTINGS.num_msgs):
+            yield self.OUTPUT_SIGNAL, AxisArray(data=np.arange(i), dims=["time"], key="odd" if i % 2 else "even")
+        raise ez.Complete
+
+
+class AxarrReceiver(ez.Unit):
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+
+    @ez.subscriber(INPUT_SIGNAL)
+    async def on_message(self, msg: AxisArray) -> None:
+        self.STATE.num_received += 1
+        with open(self.SETTINGS.output_fn, "a") as output_file:
+            payload = {self.STATE.num_received: msg.key}
+            output_file.write(json.dumps(payload) + "\n")
+        if self.STATE.num_received == self.SETTINGS.num_msgs:
+            raise ez.NormalTermination
+
+
+def test_set_key_unit():
+    num_msgs = 20
+    test_fn_raw = get_test_fn()
+    test_fn_keyed = test_fn_raw.parent / (test_fn_raw.stem + "_keyed" + test_fn_raw.suffix)
+
+    comps = {
+        "SRC": KeyedAxarrGenerator(num_msgs=num_msgs),
+        "KEYSETTER": SetKey(key="new key"),
+        "SINK_RAW": AxarrReceiver(num_msgs=1e9, output_fn=test_fn_raw),
+        "SINK_KEYED": AxarrReceiver(num_msgs=num_msgs, output_fn=test_fn_keyed),
+    }
+    conns = [
+        (comps["SRC"].OUTPUT_SIGNAL, comps["SINK_RAW"].INPUT_SIGNAL),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["KEYSETTER"].INPUT_SIGNAL),
+        (comps["KEYSETTER"].OUTPUT_SIGNAL, comps["SINK_KEYED"].INPUT_SIGNAL),
+    ]
+    ez.run(
+        components=comps,
+        connections=conns
+    )
+
+    with open(test_fn_raw, "r") as file:
+        raw_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_raw)
+    assert len(raw_results) == num_msgs
+    assert all([_[str(ix + 1)] == ("odd" if ix % 2 else "even") for ix, _ in enumerate(raw_results)])
+
+    with open(test_fn_keyed, "r") as file:
+        keyed_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_keyed)
+    assert len(keyed_results) == num_msgs
+    assert all([_[str(ix + 1)] == "new key" for ix, _ in enumerate(keyed_results)])
+
+
+def test_filter_key():
+    num_msgs = 20
+    test_fn_raw = get_test_fn()
+    test_fn_filtered = test_fn_raw.parent / (test_fn_raw.stem + "_keyed" + test_fn_raw.suffix)
+
+    comps = {
+        "SRC": KeyedAxarrGenerator(num_msgs=num_msgs),
+        "FILTER": FilterOnKey(key="odd"),
+        "SINK_RAW": AxarrReceiver(num_msgs=1e9, output_fn=test_fn_raw),
+        "SINK_FILTERED": AxarrReceiver(num_msgs=num_msgs // 2, output_fn=test_fn_filtered),
+    }
+    conns = [
+        (comps["SRC"].OUTPUT_SIGNAL, comps["SINK_RAW"].INPUT_SIGNAL),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["FILTER"].INPUT_SIGNAL),
+        (comps["FILTER"].OUTPUT_SIGNAL, comps["SINK_FILTERED"].INPUT_SIGNAL),
+    ]
+    ez.run(
+        components=comps,
+        connections=conns
+    )
+
+    with open(test_fn_raw, "r") as file:
+        raw_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_raw)
+    assert len(raw_results) == num_msgs
+
+    with open(test_fn_filtered, "r") as file:
+        filtered_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_filtered)
+    assert len(filtered_results) == num_msgs // 2
+    assert all([_[str(ix + 1)] == "odd" for ix, _ in enumerate(filtered_results)])


### PR DESCRIPTION
(ignore array_chunker commits)

Closes #142 

This PR adds a `.key` field to AxisArray then adds a couple functionalities related to it:

* `AxisArray.concat(..., filter_key="some key")` will only concatenate messages with matching keys
* `AxisArray.concat(..., filter_key=None)` (default) will not filter but will set key to `""` (default) if keys are not matching.
* `set_key` generator or `SetKey` Unit sets the .key field to a new value.
* `FilterOnKey` (Unit only) only allows through messages with matching .key value.