### PR TITLE
Add key field to AxisArray structure, with a Unit to set the key and another to filter on key

### DIFF
--- a/src/ezmsg/util/messages/key.py
+++ b/src/ezmsg/util/messages/key.py
@@ -1,0 +1,89 @@
+from dataclasses import replace
+import traceback
+import typing
+
+import numpy as np
+
+import ezmsg.core as ez
+from .axisarray import AxisArray
+from ..generator import consumer, GenState
+
+
+@consumer
+def set_key(
+    key: str = ""
+) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Set the key of an AxisArray.
+
+    Args:
+        key: The string to set as the key.
+
+    Returns:
+        A primed generator object ready to yield an AxisArray with the key set for each .send(axis_array)
+    """
+    # State variables
+    axis_arr_in = AxisArray(np.array([]), dims=[""])
+    axis_arr_out = AxisArray(np.array([]), dims=[""])
+
+    while True:
+        axis_arr_in = yield axis_arr_out
+
+        axis_arr_out = replace(axis_arr_in, key=key)
+
+
+class KeySettings(ez.Settings):
+    key: str = ""
+
+
+class SetKey(ez.Unit):
+    STATE = GenState
+    SETTINGS = KeySettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+    INPUT_SETTINGS = ez.InputStream(ez.Settings)
+
+    async def initialize(self) -> None:
+        self.construct_generator()
+
+    def construct_generator(self):
+        self.STATE.gen = set_key(key=self.SETTINGS.key)
+
+    @ez.subscriber(INPUT_SETTINGS)
+    async def on_settings(self, msg: ez.Settings) -> None:
+        self.apply_settings(msg)
+        self.construct_generator()
+
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def on_message(self, message: AxisArray) -> typing.AsyncGenerator:
+        try:
+            ret = self.STATE.gen.send(message)
+            if ret is not None:
+                yield self.OUTPUT_SIGNAL, ret
+        except (StopIteration, GeneratorExit):
+            ez.logger.debug(f"SetKey closed in {self.address}")
+        except Exception:
+            ez.logger.info(traceback.format_exc())
+
+
+class FilterOnKey(ez.Unit):
+    """
+    Filter an AxisArray based on its key.
+    Note: There is no associated generator method for this Unit because messages that fail the filter
+     would still be yielded (as None), which complicates downstream processing. For contexts where filtering
+     on key is desired but the ezmsg framework is not used, use normal Python functional programming.
+     See https://github.com/ezmsg-org/ezmsg/issues/142#issuecomment-2323110318
+    """
+    SETTINGS = KeySettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def on_message(self, message: AxisArray) -> typing.AsyncGenerator:
+        if message.key == self.SETTINGS.key:
+            out = replace(message, key=message.key)  # Minimal 'touch' to prevent deepcopy by framework
+            yield self.OUTPUT_SIGNAL, out

--- a/tests/messages/test_key.py
+++ b/tests/messages/test_key.py
@@ -1,0 +1,134 @@
+import copy
+import json
+import os
+import typing
+
+import numpy as np
+
+import ezmsg.core as ez
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.key import set_key, SetKey, FilterOnKey
+from ..ez_test_utils import (
+    get_test_fn,
+    MessageGeneratorSettings,
+    MessageReceiverSettings,
+    MessageReceiverState,
+)
+
+
+def test_set_key():
+    input_ax_arr = AxisArray(
+        data=np.arange(60).reshape(3, 5, 4),
+        dims=["step", "freq", "ch"],
+        axes={"step": AxisArray.Axis.TimeAxis(fs=10.0, offset=0.0)},
+        key="old key"
+    )
+    backup = copy.deepcopy(input_ax_arr)
+
+    gen = set_key(key="new key")
+    res = gen.send(input_ax_arr)
+
+    # Make sure the input hasn't changed
+    assert np.array_equal(input_ax_arr.data, backup.data)
+    assert input_ax_arr.dims == backup.dims
+    assert list(input_ax_arr.axes.keys()) == list(backup.axes.keys())
+    for k, v in input_ax_arr.axes.items():
+        assert v == backup.axes[k]
+
+    # We don't want the data to be copied
+    assert res.data is input_ax_arr.data
+
+    assert res.key == "new key"
+
+
+class KeyedAxarrGenerator(ez.Unit):
+    SETTINGS = MessageGeneratorSettings
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def spawn(self) -> typing.AsyncGenerator:
+        for i in range(self.SETTINGS.num_msgs):
+            yield self.OUTPUT_SIGNAL, AxisArray(data=np.arange(i), dims=["time"], key="odd" if i % 2 else "even")
+        raise ez.Complete
+
+
+class AxarrReceiver(ez.Unit):
+    STATE = MessageReceiverState
+    SETTINGS = MessageReceiverSettings
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+
+    @ez.subscriber(INPUT_SIGNAL)
+    async def on_message(self, msg: AxisArray) -> None:
+        self.STATE.num_received += 1
+        with open(self.SETTINGS.output_fn, "a") as output_file:
+            payload = {self.STATE.num_received: msg.key}
+            output_file.write(json.dumps(payload) + "\n")
+        if self.STATE.num_received == self.SETTINGS.num_msgs:
+            raise ez.NormalTermination
+
+
+def test_set_key_unit():
+    num_msgs = 20
+    test_fn_raw = get_test_fn()
+    test_fn_keyed = test_fn_raw.parent / (test_fn_raw.stem + "_keyed" + test_fn_raw.suffix)
+
+    comps = {
+        "SRC": KeyedAxarrGenerator(num_msgs=num_msgs),
+        "KEYSETTER": SetKey(key="new key"),
+        "SINK_RAW": AxarrReceiver(num_msgs=1e9, output_fn=test_fn_raw),
+        "SINK_KEYED": AxarrReceiver(num_msgs=num_msgs, output_fn=test_fn_keyed),
+    }
+    conns = [
+        (comps["SRC"].OUTPUT_SIGNAL, comps["SINK_RAW"].INPUT_SIGNAL),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["KEYSETTER"].INPUT_SIGNAL),
+        (comps["KEYSETTER"].OUTPUT_SIGNAL, comps["SINK_KEYED"].INPUT_SIGNAL),
+    ]
+    ez.run(
+        components=comps,
+        connections=conns
+    )
+
+    with open(test_fn_raw, "r") as file:
+        raw_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_raw)
+    assert len(raw_results) == num_msgs
+    assert all([_[str(ix + 1)] == ("odd" if ix % 2 else "even") for ix, _ in enumerate(raw_results)])
+
+    with open(test_fn_keyed, "r") as file:
+        keyed_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_keyed)
+    assert len(keyed_results) == num_msgs
+    assert all([_[str(ix + 1)] == "new key" for ix, _ in enumerate(keyed_results)])
+
+
+def test_filter_key():
+    num_msgs = 20
+    test_fn_raw = get_test_fn()
+    test_fn_filtered = test_fn_raw.parent / (test_fn_raw.stem + "_keyed" + test_fn_raw.suffix)
+
+    comps = {
+        "SRC": KeyedAxarrGenerator(num_msgs=num_msgs),
+        "FILTER": FilterOnKey(key="odd"),
+        "SINK_RAW": AxarrReceiver(num_msgs=1e9, output_fn=test_fn_raw),
+        "SINK_FILTERED": AxarrReceiver(num_msgs=num_msgs // 2, output_fn=test_fn_filtered),
+    }
+    conns = [
+        (comps["SRC"].OUTPUT_SIGNAL, comps["SINK_RAW"].INPUT_SIGNAL),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["FILTER"].INPUT_SIGNAL),
+        (comps["FILTER"].OUTPUT_SIGNAL, comps["SINK_FILTERED"].INPUT_SIGNAL),
+    ]
+    ez.run(
+        components=comps,
+        connections=conns
+    )
+
+    with open(test_fn_raw, "r") as file:
+        raw_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_raw)
+    assert len(raw_results) == num_msgs
+
+    with open(test_fn_filtered, "r") as file:
+        filtered_results = [json.loads(_) for _ in file.readlines()]
+    os.remove(test_fn_filtered)
+    assert len(filtered_results) == num_msgs // 2
+    assert all([_[str(ix + 1)] == "odd" for ix, _ in enumerate(filtered_results)])


### PR DESCRIPTION
This PR adds a `.key` field to AxisArray then adds a couple functionalities related to it:

* `AxisArray.concat(..., filter_key="some key")` will only concatenate messages with matching keys
* `AxisArray.concat(..., filter_key=None)` (default) will not filter but will set key to `""` (default) if keys are not matching.
* `set_key` generator or `SetKey` Unit sets the .key field to a new value.
* `FilterOnKey` (Unit only) only allows through messages with matching .key value.

This is a redo of #145 without the ArrayChunker stuff.
