### PR TITLE
resample_axes functionality for AxisArray

### DIFF
--- a/src/ezmsg/util/messages/axisarray.py
+++ b/src/ezmsg/util/messages/axisarray.py
@@ -154,6 +154,25 @@ class AxisArray:
         """Deprecated; use axis_idx instead"""
         return self.axis_idx(dim)
 
+    def resample_axes(self, **axes_kwargs: typing.Any) -> "AxisArray":
+        """
+        Resample specified axes to a new sampling frequency.
+
+        Args:
+            **axes_kwargs: Key-value pairs of existing axes and their new sampling rates.
+
+        Returns:
+            The modified instance of the AxisArray.
+
+        Raises:
+            KeyError: If the axis dimension does not exist.
+        """
+        for dim, fs in axes_kwargs.items():
+            if dim not in self.axes.keys():
+                raise KeyError(f"{dim=} not a valid axis to resample.")
+            self.axes[dim] = AxisArray.Axis.TimeAxis(fs)
+        return self
+
     def as2d(self, dim: typing.Union[str, int]) -> npt.NDArray:
         return as2d(self.data, self.axis_idx(dim))
 

--- a/src/ezmsg/util/messages/axisarray.py
+++ b/src/ezmsg/util/messages/axisarray.py
@@ -170,7 +170,7 @@ class AxisArray:
         for dim, fs in axes_kwargs.items():
             if dim not in self.axes.keys():
                 raise KeyError(f"{dim=} not a valid axis to resample.")
-            self.axes[dim] = AxisArray.Axis.TimeAxis(fs)
+            self.axes[dim] = AxisArray.Axis.TimeAxis(fs, offset=self.axes[dim].offset)
         return self
 
     def as2d(self, dim: typing.Union[str, int]) -> npt.NDArray:

--- a/tests/messages/test_axisarray.py
+++ b/tests/messages/test_axisarray.py
@@ -236,7 +236,7 @@ def test_resample_axes():
         data=np.arange(5000).reshape((1000, 5)),
         dims=["Time", "Channels"],
         axes={
-            "Time": AxisArray.Axis.TimeAxis(fs=1000),
+            "Time": AxisArray.Axis.TimeAxis(fs=1000, offset=100),
             "Channels": AxisArray.Axis()
         },
         new_field = 5
@@ -245,4 +245,4 @@ def test_resample_axes():
     result = modify(msg)
     assert type(result) == CostumAxisArray
     assert result.new_field == 5
-    assert result.axes["Time"] == AxisArray.Axis.TimeAxis(fs=500)
+    assert result.axes["Time"] == AxisArray.Axis.TimeAxis(fs=500, offset=100)


### PR DESCRIPTION
I added a function that lets you resample more conveniently the axes of an AxisArray object. This can be particularly helpful if the message class is inheriting from AxisArray but where the unit is only exposed to the AxisArray interface. Having a resampling function in AxisArray reduces a lot of repeating code to reconfigure the necessary axes in the units. Example:
```python
async def process(self, msg: AxisArray) -> AsyncGenerator:
    # ...
    yield self.OUTPUT, replace(msg, data=data).resample_axes(Time=500)
```