### PR TITLE
Move numpy dep from required to extras - AxisArray and test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.24.4",
     "typing-extensions >= 4.9.0",
 ]
 
@@ -26,8 +25,12 @@ test = [
   "pytest-cov>=5.0.0",
   "flake8>=5.0.4",
   "xarray>=2023.1.0;python_version<'3.13'",
+  "numpy>=1.24.4",
 ]
 docs = ["sphinx<=7.2", "sphinx-rtd-theme==2.0.0", "ezmsg-sigproc>=1.2.3"]
+axisarray = [
+    "numpy>=1.24.4",
+]
 
 
 [project.scripts]

--- a/src/ezmsg/util/messages/axisarray.py
+++ b/src/ezmsg/util/messages/axisarray.py
@@ -1,17 +1,24 @@
+from abc import abstractmethod, ABC
+from contextlib import contextmanager
+from dataclasses import field, dataclass
 import math
 import typing
 import warnings
 
-from abc import abstractmethod, ABC
-from contextlib import contextmanager
-from dataclasses import field, dataclass
+import ezmsg.core as ez
 
-import numpy as np
-import numpy.typing as npt
-import numpy.lib.stride_tricks as nps
+try:
+    import numpy as np
+    import numpy.typing as npt
+    import numpy.lib.stride_tricks as nps
+except ModuleNotFoundError:
+    ez.logger.error("Install ezmsg with the AxisArray extra:"
+                    'pip install "ezmsg[AxisArray]"')
+    raise
 
 from ezmsg.core.util import either_dict_or_kwargs
 from .util import replace
+
 
 if typing.TYPE_CHECKING:
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+axisarray = [
+    { name = "numpy" },
+]
 docs = [
     { name = "ezmsg-sigproc" },
     { name = "sphinx" },
@@ -258,7 +261,8 @@ test = [
 requires-dist = [
     { name = "ezmsg-sigproc", marker = "extra == 'docs'", specifier = ">=1.2.3" },
     { name = "flake8", marker = "extra == 'test'", specifier = ">=5.0.4" },
-    { name = "numpy", marker = "extra == 'test'", specifier = ">=1.24.2" },
+    { name = "numpy", marker = "extra == 'axisarray'", specifier = ">=1.24.4" },
+    { name = "numpy", marker = "extra == 'test'", specifier = ">=1.24.4" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.8" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },


### PR DESCRIPTION
Closes #160 
* Moves numpy dep from required to extras - AxisArray and test
* Adds helpful error message when user attempts to import from `.axisarray` and numpy is not installed.
