### PR TITLE
Fix: Write buffering in MessageLogger

### DIFF
--- a/src/ezmsg/util/messagelogger.py
+++ b/src/ezmsg/util/messagelogger.py
@@ -1,5 +1,6 @@
 import json
 import time
+import typing
 
 from io import TextIOWrapper
 from dataclasses import field
@@ -8,11 +9,10 @@ from pathlib import Path
 import ezmsg.core as ez
 
 from .messagecodec import MessageEncoder, LogStart
+from .rate import Rate
 
-from typing import Optional, Any, Dict, AsyncGenerator
 
-
-def log_object(obj: Any) -> str:
+def log_object(obj: typing.Any) -> str:
     return json.dumps({"ts": time.time(), "obj": obj}, cls=MessageEncoder)
 
 
@@ -23,13 +23,18 @@ class MessageLoggerSettings(ez.Settings):
     Args:
         output: :py:class:`pathlib.Path` for a file where the messages will be logged.
             If the file path already exists, the existing file will be truncated to 0 length.
+        write_period: Period in seconds for performing a write to disk.
+            If <=0, write incoming messages to disk immediately, applying backpressure as needed.
+            If >0, messages are buffered and periodically written to disk in a separate task
     """
 
-    output: Optional[Path] = None
+    output: typing.Optional[Path] = None
+    write_period: float = 0.0 # sec
 
 
 class MessageLoggerState(ez.State):
-    output_files: Dict[Path, TextIOWrapper] = field(default_factory=dict)
+    output_files: typing.Dict[Path, TextIOWrapper] = field(default_factory=dict)
+    write_buffer: typing.List[str] = field(default_factory=list)
 
 
 class MessageLogger(ez.Unit):
@@ -55,10 +60,10 @@ class MessageLogger(ez.Unit):
     to stop logging messages to that path.
     """
 
-    INPUT_MESSAGE = ez.InputStream(Any)
+    INPUT_MESSAGE = ez.InputStream(typing.Any)
     """Pass a piece of data to log it to every open file which the ``MessageLogger`` is using."""
 
-    OUTPUT_MESSAGE = ez.OutputStream(Any)
+    OUTPUT_MESSAGE = ez.OutputStream(typing.Any)
     """Messages which are sent to ``INPUT_MESSAGE`` will pass through and be published on ``OUTPUT_MESSAGE``."""
 
     OUTPUT_START = ez.OutputStream(Path)
@@ -69,7 +74,7 @@ class MessageLogger(ez.Unit):
     """If a file passed to ``INPUT_STOP`` is successfully closed, its path will be published to
     ``OUTPUT_STOP``, otherwise ``None``."""
 
-    def open_file(self, filepath: Path) -> Optional[Path]:
+    def open_file(self, filepath: Path) -> typing.Optional[Path]:
         """Returns file path if file successfully opened, otherwise None"""
         if filepath in self.STATE.output_files:
             # If the file is already open, we return None
@@ -85,7 +90,7 @@ class MessageLogger(ez.Unit):
 
         return filepath
 
-    def close_file(self, filepath: Path) -> Optional[Path]:
+    def close_file(self, filepath: Path) -> typing.Optional[Path]:
         """Returns file path if file successfully closed, otherwise None"""
         if filepath not in self.STATE.output_files:
             # We haven't opened this file
@@ -103,28 +108,53 @@ class MessageLogger(ez.Unit):
 
     @ez.subscriber(INPUT_START)
     @ez.publisher(OUTPUT_START)
-    async def start_file(self, message: Path) -> AsyncGenerator:
+    async def start_file(self, message: Path) -> typing.AsyncGenerator:
         out = self.open_file(message)
         if out is not None:
             yield (self.OUTPUT_START, out)
 
     @ez.subscriber(INPUT_STOP)
     @ez.publisher(OUTPUT_STOP)
-    async def stop_file(self, message: Path) -> AsyncGenerator:
+    async def stop_file(self, message: Path) -> typing.AsyncGenerator:
         out = self.close_file(message)
         if out is not None:
             yield (self.OUTPUT_STOP, out)
 
     @ez.subscriber(INPUT_MESSAGE)
     @ez.publisher(OUTPUT_MESSAGE)
-    async def on_message(self, message: Any) -> AsyncGenerator:
-        strmessage = log_object(message)
-        for output_f in self.STATE.output_files.values():
-            output_f.write(f"{strmessage}\n")
-            output_f.flush()
+    async def on_message(self, message: typing.Any) -> typing.AsyncGenerator:
+        strmessage = f"{log_object(message)}\n"
+
+        if self.SETTINGS.write_period <= 0:
+            for output_f in self.STATE.output_files.values():
+                output_f.write(strmessage)
+                output_f.flush()
+        else:
+            self.STATE.write_buffer.append(strmessage)
+
         yield (self.OUTPUT_MESSAGE, message)
+
+    @ez.task
+    async def buffered_write(self) -> None:
+        if self.SETTINGS.write_period <= 0:
+            return
+        
+        rate = Rate(1.0 / self.SETTINGS.write_period)
+        while True:
+            for output_f in self.STATE.output_files.values():
+                output_f.writelines(self.STATE.write_buffer)
+                output_f.flush()
+            self.STATE.write_buffer.clear()
+            await rate.sleep()
 
     async def shutdown(self) -> None:
         """Note that files that are closed at shutdown don't publish messages"""
+
+        if len(self.STATE.write_buffer):
+            for output_f in self.STATE.output_files.values():
+                output_f.writelines(self.STATE.write_buffer)
+                output_f.flush()
+            self.STATE.write_buffer.clear()
+
         for filepath in list(self.STATE.output_files):
             self.close_file(filepath)


### PR DESCRIPTION
Sometimes we want message channels with high message rates and low `num_buffers` to enable low-latency real-time processing.  Logging data on those message channels currently leads to lots of backpressure, especially on systems where disk I/O can be slow to start (Pi running on SD-card).

In these situations, it can be advantageous to buffer messages and write to disk on a separate task every so often.  This "fix"  (feature?) lets you do that by specifying a `write_period` in the `MessageLoggerSettings`. 

The default value of zero maintains current behavior, which guarantees the message is written to disk before the message channel is cleared; causing backpressure if disk IO cannot keep up, but delivering a guarantee that all messages have been written to disk exactly when received.  Specifying a positive non-zero `write_period` will result in buffering of messages and kicks off a task that writes these messages every `write_period` seconds.  On shutdown, buffered messages are written to disk before the system shuts down.