### PR TITLE
Add --nobrowser argument for mermaid graph visualization

### DIFF
--- a/src/ezmsg/core/command.py
+++ b/src/ezmsg/core/command.py
@@ -62,11 +62,19 @@ def cmdline() -> None:
         action="count",
     )
 
+    parser.add_argument(
+        "-n",
+        "--nobrowser",
+        help="Do not automatically open the browser for mermaid output. `--target` value will be ignored.",
+        action="store_true",
+    )
+
     class Args:
         command: str
         address: typing.Optional[str]
         target: str
         compact: typing.Optional[int]
+        nobrowser: bool
 
     args = parser.parse_args(namespace=Args)
 
@@ -82,7 +90,14 @@ def cmdline() -> None:
     asyncio.set_event_loop(loop)
 
     loop.run_until_complete(
-        run_command(args.command, graph_address, shm_address, args.target, args.compact)
+        run_command(
+            args.command,
+            graph_address,
+            shm_address,
+            args.target,
+            args.compact,
+            args.nobrowser,
+        )
     )
 
 
@@ -92,6 +107,7 @@ async def run_command(
     shm_address: Address,
     target: str = "live",
     compact: typing.Optional[int] = None,
+    nobrowser: bool = False,
 ) -> None:
     shm_service = SHMService(shm_address)
     graph_service = GraphService(graph_address)
@@ -152,11 +168,12 @@ async def run_command(
         )
         print(graph_out)
         if cmd == "mermaid":
-            if target == "live":
-                print(
-                    "%% If the graph does not render immediately, try toggling the 'Pan & Zoom' button."
-                )
-            webbrowser.open(mm(graph_out, target=target))
+            if not nobrowser:
+                if target == "live":
+                    print(
+                        "%% If the graph does not render immediately, try toggling the 'Pan & Zoom' button."
+                    )
+                webbrowser.open(mm(graph_out, target=target))
 
 
 def mm(graph: str, target="live") -> str:

--- a/src/ezmsg/core/dag.py
+++ b/src/ezmsg/core/dag.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
-
 from typing import List, Set, DefaultDict
 
 
@@ -42,9 +41,8 @@ class DAG:
         test_graph[from_node].add(to_node)
         test_graph[to_node]
 
-        for node in test_graph.keys():
-            if node in _bfs(test_graph, node):
-                raise CyclicException
+        if from_node in _bfs(test_graph, from_node):
+            raise CyclicException
 
         # No cycles!  Modify referenced data structure
         self.graph[from_node].add(to_node)
@@ -79,9 +77,7 @@ def _leaves(graph: GraphType) -> Set[str]:
     return set([f for f, t in graph.items() if len(t) == 0])
 
 
-# Bredth First Search of a graph
-
-
+# Breadth First Search of a graph
 def _bfs(graph: GraphType, node: str) -> List[str]:
     connected: Set[str] = set()
     queue = [node]

--- a/src/ezmsg/core/graph_util.py
+++ b/src/ezmsg/core/graph_util.py
@@ -1,0 +1,251 @@
+from collections import defaultdict
+from textwrap import indent
+from typing import Set, DefaultDict, Optional, Tuple, List
+from uuid import uuid4
+
+
+GraphType = DefaultDict[str, Set[str]]
+IND = "  "
+
+
+def prune_graph_connections(
+    graph_connections: GraphType,
+) -> Tuple[Optional[GraphType], Optional[List[str]]]:
+    """
+    Remove nodes from the graph that are proxy_topics, i.e. nodes that are both
+    source and target nodes in the connections graph.
+    """
+    graph_conns = graph_connections.copy()
+    source_nodes = []
+    for node, conns in graph_conns.items():
+        if len(conns) > 0:
+            source_nodes += [node]
+    proxy_topics = []
+    for conns in graph_conns.values():
+        for conn in conns:
+            if conn in source_nodes and conn not in proxy_topics:
+                proxy_topics += [conn]
+
+    # Replace Proxy Topics with actual source and downstream
+    for proxy_topic in proxy_topics:
+        downstreams = graph_conns.pop(proxy_topic)
+        for node, conns in graph_conns.items():
+            for conn in conns:
+                if conn == proxy_topic:
+                    new_conns = conns.copy()
+                    new_conns.remove(proxy_topic)
+                    new_conns |= downstreams
+                    graph_conns[node] = new_conns
+
+    return graph_conns, proxy_topics
+
+
+def _pipeline_levels(
+    graph_connections: GraphType, level_separator: str = "/"
+) -> defaultdict:
+    """
+    In ezmsg, a pipeline is built with units/collections, with subcomponents
+    that are either more units/collection or input/output streams. The graph of
+    the connections are stored in a DAG (directed acyclic graph object), but the
+    nodes themselves represent the hierarchical levels of the pipeline in their
+    names which are strings of the form `top_level/sub_level/.../node_name`, where
+    each level is separated by a level separator (default is `/`).
+    This function computes the level of each component in the hierarchy (not just
+    the connection nodes) and returns a dictionary of the level of each pipeline
+    parts, where 0 is the level of the connection (leaf) nodes.
+    """
+    graph_levels = defaultdict(int)
+
+    def update_level(node: str) -> None:
+        """
+        Update levels of a leaf node and all pipeline parent nodes.
+        Note, assumes node is a leaf node of the forest.
+        """
+        depth = 0
+        while len(node) > 0:
+            graph_levels[node] = max(graph_levels[node], depth)
+            node = _get_parent_node(node, level_separator)
+            depth += 1
+
+    for node, conns in graph_connections.items():
+        update_level(node)
+        for conn in conns:
+            update_level(conn)
+
+    return graph_levels
+
+
+def _get_parent_node(node: str, level_separator: str = "/") -> str:
+    return node.rsplit(level_separator, 1)[0] if level_separator in node else ""
+
+
+class LeafNodeException(Exception):
+    """Raised when connection nodes are not leaf nodes in the pipeline hierarchy."""
+
+
+def get_compactified_graph(
+    graph_connections: GraphType, compact_level: int = 0, level_separator: str = "/"
+) -> GraphType:
+    """
+    Used for graphical visualization of ezmsg pipelines.
+    Compactifies the graph connections dictionary by removing all parts that
+    are at levels < compact level. Leaf nodes (streams in ezmsg) are level 0,
+    so removing only them requires compact_level = 1.
+    *Note: When collections contain streams at the same level as subunits or
+    subcollections, removing them can make the pipeline diagram unclear, so
+    they are left as is.
+    Returns graph of compactified connections.
+    Note: compactified graphs need no longer be DAGs.
+    """
+
+    if compact_level == 0 or len(graph_connections) == 0:
+        return graph_connections
+
+    try:
+        graph_levels = _validate_connections_are_leaf_nodes(
+            graph_connections, level_separator
+        )
+    except LeafNodeException as e:
+        raise LeafNodeException(f"Cannot compactify graph: {e}") from e
+
+    def get_node_update(node: str) -> str:
+        if node not in update_node_map:
+            parent_node = _get_parent_node(node, level_separator)
+            if parent_node == "":
+                # don't update node if it's already a forest root (i.e., no parent)
+                update_node_map[node] = node
+            else:
+                node_level = graph_levels[node]
+                if graph_levels[parent_node] == node_level + 1:
+                    # node is in component with all subcomponents at same level
+                    update_node_map[node] = parent_node
+                else:
+                    # node is in component with deeper subcomponents than node
+                    graph_levels[node] += node_level + 1
+                    update_node_map[node] = node
+        return update_node_map[node]
+
+    level = 0
+    while level < compact_level:
+        update_node_map = defaultdict(str)
+        temp_connections = defaultdict(set)
+        for node, conns in graph_connections.items():
+            source = get_node_update(node)
+            targets = [get_node_update(conn) for conn in conns]
+            temp_connections[source] |= set(targets)
+            temp_connections[source].discard(source)
+        level += 1
+        graph_connections = temp_connections
+
+    return graph_connections
+
+
+def _validate_connections_are_leaf_nodes(
+    graph_connections: GraphType, level_separator: str = "/"
+) -> defaultdict:
+    """
+    Validate that all nodes in the graph_connections dictionary are leaf nodes in the
+    pipeline hierarchy that is represented in the node names. See `forest_levels` for
+    more details on the hierarchy.
+    """
+    graph_levels = _pipeline_levels(graph_connections, level_separator)
+    for leaf_node, leaf_conns in graph_connections.items():
+        nodes = [leaf_node] + [conn for conn in leaf_conns]
+        for node in nodes:
+            if graph_levels[node] != 0:
+                raise LeafNodeException(
+                    f"The node '{node}' is a connection node, but not a leaf node in the pipeline hierarchy."
+                )
+    return graph_levels
+
+
+def graph_string(
+    graph_connections: GraphType,
+    fmt: str,
+    direction: str = "LR",
+    level_separator: str = "/",
+) -> str:
+    """
+    Returns a string representation of the graph connections for displaying with mermaid or graphviz.
+    """
+    if fmt not in ["mermaid", "graphviz"]:
+        raise ValueError(f"Invalid format '{fmt}'. Options are 'mermaid' or 'graphviz'")
+
+    # Let's come up with UUID node names
+    node_map = {}
+    for name in graph_connections.keys():
+        if fmt == "mermaid":
+            node_map.setdefault(name, f"{str(uuid4())}")
+        else:
+            node_map.setdefault(name, f'"{str(uuid4())}"')
+
+    # Construct the graph
+    def tree():
+        return defaultdict(tree)
+
+    graph: defaultdict = tree()
+
+    connections = ""
+    for node, conns in graph_connections.items():
+        subgraph = graph
+        path = node.split(level_separator)
+        for seg in path[:-1]:
+            subgraph = subgraph[seg]
+        subgraph[path[-1]] = node
+
+        for conn in sorted(conns):
+            if fmt == "mermaid":
+                connections += f"{node_map[node]} --> {node_map[conn]}" + "\n"
+            else:  # fmt == "graphviz"
+                connections += f"{node_map[node]} -> {node_map[conn]};" + "\n"
+
+    if fmt == "graphviz":
+        header = [
+            "digraph EZ {",
+            indent(f'rankdir="{direction}"', IND),
+        ]
+        footer = ["}"]
+
+        def node_string(graph: defaultdict, node: str) -> Optional[str]:
+            out = None
+            if isinstance(graph[node], defaultdict):
+                out = [
+                    f"subgraph {node.lower()} {{",
+                    indent("cluster = true;", IND),
+                    indent(f'label = "{node}";', IND),
+                    f"{graph_structure_string(graph[node])}}};",
+                ]
+            elif isinstance(graph[node], str):
+                out = [f"{node_map[graph[node]]} [label={node}];"]
+            return out
+
+    else:  # fmt == mermaid
+        header = [f"flowchart {direction}"]
+        footer = []
+
+        def node_string(graph: defaultdict, node: str) -> Optional[str]:
+            out = None
+            if isinstance(graph[node], defaultdict):
+                out = [
+                    f"subgraph {node.lower()} [{node}]",
+                    # "direction LR",
+                    f"{graph_structure_string(graph[node])}",
+                    "end",
+                ]
+            elif isinstance(graph[node], str):
+                out = [f"{node_map[graph[node]]}[{node}]"]
+            return out
+
+    def graph_structure_string(graph: defaultdict) -> str:
+        out = ""
+        for node in graph:
+            node_string_list = node_string(graph, node)
+            if node_string_list is not None:
+                node_string_list += [""]  # Append a newline
+                out += indent("\n".join(node_string_list), IND)
+        return out[:-1]
+
+    graph_out = "\n".join(
+        header + [graph_structure_string(graph), indent(connections, IND)] + footer
+    )
+    return graph_out

--- a/src/ezmsg/core/graphserver.py
+++ b/src/ezmsg/core/graphserver.py
@@ -1,10 +1,7 @@
 import asyncio
-from collections import defaultdict
 import logging
 import pickle
-from textwrap import indent
 import typing
-from uuid import uuid4
 
 from contextlib import suppress
 
@@ -13,6 +10,7 @@ from uuid import UUID, uuid1, getnode
 from . import __version__
 from .server import ThreadedAsyncServer, ServiceManager
 from .dag import DAG, CyclicException
+from .graph_util import get_compactified_graph, graph_string, prune_graph_connections
 from .netprotocol import (
     Address,
     close_stream_writer,
@@ -30,8 +28,6 @@ from .netprotocol import (
 )
 
 logger = logging.getLogger("ezmsg")
-
-IND = "  "
 
 
 class GraphServer(ThreadedAsyncServer):
@@ -315,130 +311,38 @@ class GraphService(ServiceManager[GraphServer]):
         await close_stream_writer(writer)
         return dag
 
-    async def get_pruned_graph(self) -> typing.Optional[defaultdict[str, set[str]]]:
+    async def get_formatted_graph(
+        self,
+        fmt: str,
+        direction: str = "LR",
+        compact_level: typing.Optional[int] = None,
+    ) -> str:
+        if fmt not in ["mermaid", "graphviz"]:
+            raise ValueError(
+                f"Invalid format '{fmt}'. Options are 'mermaid' or 'graphviz'"
+            )
         try:
             dag: DAG = await self.dag()
         except (ConnectionRefusedError, ConnectionResetError):
             logger.info(
                 f"GraphServer not running @{self.address}, or host is refusing connections"
             )
-            return None
-
         graph_connections = dag.graph.copy()
-        # Let's eliminate proxy topics, i.e. connections with inputs and outputs.
-        source_nodes = []
-        for node, conns in graph_connections.items():
-            if len(conns) > 0:
-                source_nodes += [node]
-        proxy_topics = []
-        for conns in graph_connections.values():
-            for conn in conns:
-                if conn in source_nodes and conn not in proxy_topics:
-                    proxy_topics += [conn]
-        # Replace Proxy Topics with actual source and downstream
-        for proxy_topic in proxy_topics:
-            downstreams = graph_connections.pop(proxy_topic)
-            logger.info(f"{proxy_topic} downstream connections: {downstreams}")
-            for node, conns in graph_connections.items():
-                for conn in conns:
-                    if conn == proxy_topic:
-                        new_conns = conns.copy()
-                        new_conns.remove(proxy_topic)
-                        new_conns.union(downstreams)
-                        logger.info(
-                            f"Updating connections for {node} from {conns} to {new_conns}"
-                        )
-                        graph_connections[node] = new_conns
-
-        return dag.graph.copy()
-
-    async def get_formatted_graph(self, fmt: str, direction: str = "LR") -> str:
-        if fmt not in ["mermaid", "graphviz"]:
-            raise ValueError(
-                f"Invalid format '{fmt}'. Options are 'mermaid' or 'graphviz'"
-            )
-        graph_connections = await self.get_pruned_graph()
-
         if graph_connections is None or not graph_connections:
             return ""
 
-        # Let's come up with UUID node names
-        nodes = set(graph_connections.keys())
-        if fmt == "mermaid":
-            node_map = {name: f"{str(uuid4())}" for name in nodes}
-        else:
-            node_map = {name: f'"{str(uuid4())}"' for name in nodes}  # graphviz
+        if compact_level:
+            graph_connections, pruned_topics = prune_graph_connections(
+                graph_connections
+            )
+            if pruned_topics is not None and len(pruned_topics) > 0:
+                logger.info(f"Pruned the following proxy topics: {pruned_topics}.")
+            graph_connections = get_compactified_graph(
+                graph_connections,
+                compact_level,
+                "/",
+            )
 
-        # Construct the graph
-        def tree():
-            return defaultdict(tree)
+        formatted_graph = graph_string(graph_connections, fmt=fmt, direction=direction)
 
-        graph: defaultdict = tree()
-
-        connections = ""
-        for node, conns in graph_connections.items():
-            subgraph = graph
-            path = node.split("/")
-            route = path[:-1]
-            stream = path[-1]
-            for seg in route:
-                subgraph = subgraph[seg]
-            subgraph[stream] = node
-
-            for sub in conns:
-                if fmt == "mermaid":
-                    connections += f"{node_map[node]} --> {node_map[sub]}" + "\n"
-                else:
-                    connections += f"{node_map[node]} -> {node_map[sub]};" + "\n"
-
-        if fmt == "graphviz":
-            header = [
-                "digraph EZ {",
-                indent(f'rankdir="{direction}"', IND),
-            ]
-            footer = ["}"]
-
-            def per_leaf(g, leaf):
-                out = None
-                if isinstance(g[leaf], defaultdict):
-                    out = [
-                        f"subgraph {leaf.lower()} {{",
-                        indent("cluster = true;", IND),
-                        indent(f'label = "{leaf}";', IND),
-                        f"{recurse_graph(g[leaf])}}};",
-                    ]
-                elif isinstance(g[leaf], str):
-                    out = [f"{node_map[g[leaf]]} [label={leaf}];"]
-                return out
-
-        else:  # fmt == mermaid
-            header = [f"flowchart {direction}"]
-            footer = []
-
-            def per_leaf(g, leaf):
-                out = None
-                if isinstance(g[leaf], defaultdict):
-                    out = [
-                        f"subgraph {leaf.lower()} [{leaf}]",
-                        # "direction LR",
-                        f"{recurse_graph(g[leaf])}",
-                        "end",
-                    ]
-                elif isinstance(g[leaf], str):
-                    out = [f"{node_map[g[leaf]]}[{leaf}]"]
-                return out
-
-        def recurse_graph(g: defaultdict):
-            out = ""
-            for leaf in g:
-                leaf_list = per_leaf(g, leaf)
-                if leaf_list is not None:
-                    leaf_list += [""]  # Append a newline
-                    out += indent("\n".join(leaf_list), IND)
-            return out[:-1]
-
-        graph_out = "\n".join(
-            header + [recurse_graph(graph), indent(connections, IND)] + footer
-        )
-
-        return graph_out
+        return formatted_graph

--- a/tests/test_graph_visualization.py
+++ b/tests/test_graph_visualization.py
@@ -1,0 +1,397 @@
+import asyncio
+import logging
+import pytest
+
+from ezmsg.core.dag import DAG
+from ezmsg.core.graph_util import (
+    LeafNodeException,
+    _get_parent_node,
+    _pipeline_levels,
+    get_compactified_graph,
+    graph_string,
+    prune_graph_connections,
+)
+from ezmsg.core.graphserver import GraphService
+from ezmsg.core.netprotocol import (
+    Address,
+    GRAPHSERVER_PORT_DEFAULT,
+)
+from unittest.mock import patch, AsyncMock
+
+logger = logging.getLogger("ezmsg")
+
+TEST_GRAPH_ADDRESS = Address("127.0.0.1", GRAPHSERVER_PORT_DEFAULT)
+
+
+test_hierarchical_edges = [
+    ("SIMPLE_PUB/OUTPUT", "COLLECTION/INPUT"),
+    ("COLLECTION/INPUT", "COLLECTION/VERIFIER/INPUT"),
+    ("COLLECTION/VERIFIER/OUTPUT_SAMPLE", "COLLECTION/OUTPUT_SAMPLE"),
+    ("COLLECTION/VERIFIER/OUTPUT_SIGNAL", "COLLECTION/TERMINATE/INPUT"),
+    ("COLLECTION/VERIFIER/OUTPUT_SIGNAL", "COLLECTION/LOG/INPUT"),
+    ("COLLECTION/LOG/OUTPUT", "COLLECTION/OUTPUT_SIGNAL"),
+    ("COLLECTION/OUTPUT_SIGNAL", "SIMPLE_SUB/INPUT"),
+    ("COLLECTION/OUTPUT_SAMPLE", "SIMPLE_SUB/INPUT"),
+]
+
+
+def get_test_dag() -> DAG:
+    """
+    Returns a mock DAG for testing purposes.
+    """
+    dag = DAG()
+    for edge in test_hierarchical_edges:
+        dag.add_edge(*edge)
+    return dag
+
+
+expected_graph_connections = {
+    "SIMPLE_PUB/OUTPUT": {"COLLECTION/INPUT"},
+    "COLLECTION/INPUT": {"COLLECTION/VERIFIER/INPUT"},
+    "COLLECTION/VERIFIER/OUTPUT_SAMPLE": {"COLLECTION/OUTPUT_SAMPLE"},
+    "COLLECTION/VERIFIER/OUTPUT_SIGNAL": {
+        "COLLECTION/LOG/INPUT",
+        "COLLECTION/TERMINATE/INPUT",
+    },
+    "COLLECTION/LOG/OUTPUT": {"COLLECTION/OUTPUT_SIGNAL"},
+    "COLLECTION/OUTPUT_SIGNAL": {"SIMPLE_SUB/INPUT"},
+    "COLLECTION/OUTPUT_SAMPLE": {"SIMPLE_SUB/INPUT"},
+    "COLLECTION/VERIFIER/INPUT": set(),
+    "COLLECTION/LOG/INPUT": set(),
+    "COLLECTION/TERMINATE/INPUT": set(),
+    "SIMPLE_SUB/INPUT": set(),
+}
+expected_pruned_graph_connections = {
+    "SIMPLE_PUB/OUTPUT": {"COLLECTION/VERIFIER/INPUT"},
+    "COLLECTION/VERIFIER/OUTPUT_SAMPLE": {"SIMPLE_SUB/INPUT"},
+    "COLLECTION/VERIFIER/OUTPUT_SIGNAL": {
+        "COLLECTION/LOG/INPUT",
+        "COLLECTION/TERMINATE/INPUT",
+    },
+    "COLLECTION/LOG/OUTPUT": {"SIMPLE_SUB/INPUT"},
+    "COLLECTION/VERIFIER/INPUT": set(),
+    "COLLECTION/LOG/INPUT": set(),
+    "COLLECTION/TERMINATE/INPUT": set(),
+    "SIMPLE_SUB/INPUT": set(),
+}
+expected_pipeline_levels = {
+    "COLLECTION": 2,
+    "SIMPLE_PUB": 1,
+    "SIMPLE_SUB": 1,
+    "COLLECTION/VERIFIER": 1,
+    "COLLECTION/LOG": 1,
+    "COLLECTION/TERMINATE": 1,
+    "SIMPLE_PUB/OUTPUT": 0,
+    "COLLECTION/INPUT": 0,
+    "COLLECTION/VERIFIER/INPUT": 0,
+    "COLLECTION/VERIFIER/OUTPUT_SAMPLE": 0,
+    "COLLECTION/VERIFIER/OUTPUT_SIGNAL": 0,
+    "COLLECTION/LOG/INPUT": 0,
+    "COLLECTION/LOG/OUTPUT": 0,
+    "COLLECTION/TERMINATE/INPUT": 0,
+    "COLLECTION/OUTPUT_SIGNAL": 0,
+    "COLLECTION/OUTPUT_SAMPLE": 0,
+    "SIMPLE_SUB/INPUT": 0,
+}
+expected_compactified_graph_level1_no_prune = {
+    "SIMPLE_PUB": {"COLLECTION/INPUT"},
+    "COLLECTION/INPUT": {"COLLECTION/VERIFIER"},
+    "COLLECTION/VERIFIER": {
+        "COLLECTION/TERMINATE",
+        "COLLECTION/OUTPUT_SAMPLE",
+        "COLLECTION/LOG",
+    },
+    "COLLECTION/OUTPUT_SAMPLE": {"SIMPLE_SUB"},
+    "COLLECTION/OUTPUT_SIGNAL": {"SIMPLE_SUB"},
+    "COLLECTION/LOG": {"COLLECTION/OUTPUT_SIGNAL"},
+    "COLLECTION/TERMINATE": set(),
+    "SIMPLE_SUB": set(),
+}
+expected_compactified_graph_level1_prune = {
+    "SIMPLE_PUB": {"COLLECTION/VERIFIER"},
+    "COLLECTION/VERIFIER": {"COLLECTION/TERMINATE", "SIMPLE_SUB", "COLLECTION/LOG"},
+    "COLLECTION/LOG": {"SIMPLE_SUB"},
+    "COLLECTION/TERMINATE": set(),
+    "SIMPLE_SUB": set(),
+}
+expected_compactified_graph_level2 = {
+    "SIMPLE_PUB": {"COLLECTION"},
+    "COLLECTION": {"SIMPLE_SUB"},
+    "SIMPLE_SUB": set(),
+}
+
+
+def test_prune_graph():
+    dag = get_test_dag()
+
+    assert dict(dag.graph) == expected_graph_connections
+    pruned_graph = prune_graph_connections(dag.graph)
+    assert dict(pruned_graph[0]) == expected_pruned_graph_connections
+    assert set(pruned_graph[1]) == {
+        "COLLECTION/INPUT",
+        "COLLECTION/OUTPUT_SIGNAL",
+        "COLLECTION/OUTPUT_SAMPLE",
+    }
+
+
+def test_pipeline_levels():
+    dag = get_test_dag()
+
+    levels = _pipeline_levels(dag.graph, level_separator="/")
+    assert dict(levels) == expected_pipeline_levels
+
+
+def test_get_parent_node():
+    # Test with a valid node and level separator
+    node = "FIRST/SECOND/THIRD"
+    level_separator = "/"
+    expected_parent_node = "FIRST/SECOND"
+    parent_node = _get_parent_node(node, level_separator)
+    assert parent_node == expected_parent_node
+
+    # Test with a node that has no parent (root node)
+    node = "FIRST"
+    expected_parent_node = ""
+    parent_node = _get_parent_node(node, level_separator)
+    assert parent_node == expected_parent_node
+
+    # Test with an empty string as the node
+    node = ""
+    expected_parent_node = ""
+    parent_node = _get_parent_node(node, level_separator)
+    assert parent_node == expected_parent_node
+
+
+def test_get_compactified_graph():
+    dag = get_test_dag()
+
+    compactified_level1_no_prune = get_compactified_graph(dag.graph, compact_level=1)
+    assert (
+        dict(compactified_level1_no_prune)
+        == expected_compactified_graph_level1_no_prune
+    )
+
+    pruned_graph = prune_graph_connections(dag.graph)[0]
+    compactified_level1_prune = get_compactified_graph(pruned_graph, compact_level=1)
+    assert dict(compactified_level1_prune) == expected_compactified_graph_level1_prune
+
+    compactified_level2 = get_compactified_graph(dag.graph, compact_level=2)
+    assert dict(compactified_level2) == expected_compactified_graph_level2
+
+    # Test compactification fails when graph of connections
+    # is not between leaf nodes of pipeline
+    dag.add_edge("COLLECTION/VERIFIER", "SECOND/LOG/INPUT")
+    with pytest.raises(LeafNodeException):
+        get_compactified_graph(dag.graph, compact_level=1)
+
+
+def test_graph_string():
+    """
+    Test the graph_string function when given an incorrect format.
+    It is tested with correct formats in the test_graph_visualization function.
+    """
+    graph = DAG()
+    for edge in test_hierarchical_edges:
+        graph.add_edge(*edge)
+
+    with pytest.raises(ValueError):
+        graph_string(graph, "invalid_format")
+
+
+expected_mermaid_string = r"""flowchart LR
+  subgraph simple_pub [SIMPLE_PUB]
+    0[OUTPUT]
+  end
+  subgraph collection [COLLECTION]
+    1[INPUT]
+    subgraph verifier [VERIFIER]
+      2[INPUT]
+      3[OUTPUT_SAMPLE]
+      5[OUTPUT_SIGNAL]
+    end
+    4[OUTPUT_SAMPLE]
+    subgraph terminate [TERMINATE]
+      6[INPUT]
+    end
+    subgraph log [LOG]
+      7[INPUT]
+      8[OUTPUT]
+    end
+    9[OUTPUT_SIGNAL]
+  end
+  subgraph simple_sub [SIMPLE_SUB]
+    10[INPUT]
+  end
+  0 --> 1
+  1 --> 2
+  3 --> 4
+  4 --> 10
+  5 --> 7
+  5 --> 6
+  8 --> 9
+  9 --> 10
+"""
+expected_mermaid_string_compact = r"""flowchart LR
+  11[SIMPLE_PUB]
+  subgraph collection [COLLECTION]
+    12[VERIFIER]
+    13[TERMINATE]
+    14[LOG]
+  end
+  15[SIMPLE_SUB]
+  11 --> 12
+  12 --> 14
+  12 --> 13
+  12 --> 15
+  14 --> 15
+"""
+expected_mermaid_string_compact_compact = r"""flowchart LR
+  16[SIMPLE_PUB]
+  17[COLLECTION]
+  18[SIMPLE_SUB]
+  16 --> 17
+  17 --> 18
+"""
+expected_graphviz_string = r"""digraph EZ {
+  rankdir="LR"
+  subgraph simple_pub {
+    cluster = true;
+    label = "SIMPLE_PUB";
+    "19" [label=OUTPUT];};
+  subgraph collection {
+    cluster = true;
+    label = "COLLECTION";
+    "20" [label=INPUT];
+    subgraph verifier {
+      cluster = true;
+      label = "VERIFIER";
+      "21" [label=INPUT];
+      "22" [label=OUTPUT_SAMPLE];
+      "24" [label=OUTPUT_SIGNAL];};
+    "23" [label=OUTPUT_SAMPLE];
+    subgraph terminate {
+      cluster = true;
+      label = "TERMINATE";
+      "25" [label=INPUT];};
+    subgraph log {
+      cluster = true;
+      label = "LOG";
+      "26" [label=INPUT];
+      "27" [label=OUTPUT];};
+    "28" [label=OUTPUT_SIGNAL];};
+  subgraph simple_sub {
+    cluster = true;
+    label = "SIMPLE_SUB";
+    "29" [label=INPUT];};
+  "19" -> "20";
+  "20" -> "21";
+  "22" -> "23";
+  "23" -> "29";
+  "24" -> "26";
+  "24" -> "25";
+  "27" -> "28";
+  "28" -> "29";
+
+}"""
+expected_graphviz_string_compact = r"""digraph EZ {
+  rankdir="LR"
+  "30" [label=SIMPLE_PUB];
+  subgraph collection {
+    cluster = true;
+    label = "COLLECTION";
+    "31" [label=VERIFIER];
+    "32" [label=TERMINATE];
+    "33" [label=LOG];};
+  "34" [label=SIMPLE_SUB];
+  "30" -> "31";
+  "31" -> "33";
+  "31" -> "32";
+  "31" -> "34";
+  "33" -> "34";
+
+}"""
+expected_graphviz_string_compact_compact = r"""digraph EZ {
+  rankdir="LR"
+  "35" [label=SIMPLE_PUB];
+  "36" [label=COLLECTION];
+  "37" [label=SIMPLE_SUB];
+  "35" -> "36";
+  "36" -> "37";
+
+}"""
+
+
+@pytest.fixture
+def mock_dag():
+    """
+    Mock the dag method of GraphService to return a test DAG.
+    """
+    with patch.object(
+        GraphService, "dag", AsyncMock(return_value=get_test_dag())
+    ) as mock_dag:
+        yield mock_dag
+
+
+@pytest.fixture
+def mock_uuid4():
+    """
+    Mock function to return a reproducible UUID for testing comparison purposes.
+    """
+    mock_uuids = tuple(range(100))
+    with patch("ezmsg.core.graph_util.uuid4", side_effect=mock_uuids) as mock_uuid:
+        yield mock_uuid
+
+
+@pytest.mark.asyncio
+async def test_graph_visualization(mock_dag, mock_uuid4):
+    """
+    Test the graph visualization using the mocked DAG.
+    """
+    graph_service = GraphService()
+
+    # Test mermaid format
+    graph_mermaid = await graph_service.get_formatted_graph("mermaid")
+    assert graph_mermaid == expected_mermaid_string
+
+    # Test mermaid compact format
+    graph_mermaid_compact = await graph_service.get_formatted_graph(
+        "mermaid", compact_level=1
+    )
+    assert graph_mermaid_compact == expected_mermaid_string_compact
+
+    # Test mermaid compact x2 format
+    graph_mermaid_compact_compact = await graph_service.get_formatted_graph(
+        "mermaid", compact_level=2
+    )
+    assert graph_mermaid_compact_compact == expected_mermaid_string_compact_compact
+
+    # Test graphviz format
+    graph_graphviz = await graph_service.get_formatted_graph("graphviz")
+    assert graph_graphviz == expected_graphviz_string
+
+    # Test graphviz compact format
+    graph_graphviz_compact = await graph_service.get_formatted_graph(
+        "graphviz", compact_level=1
+    )
+    assert graph_graphviz_compact == expected_graphviz_string_compact
+
+    # Test graphviz compact x2 format
+    graph_graphviz_compact_compact = await graph_service.get_formatted_graph(
+        "graphviz", compact_level=2
+    )
+    assert graph_graphviz_compact_compact == expected_graphviz_string_compact_compact
+
+
+if __name__ == "__main__":
+    test_prune_graph()
+    test_pipeline_levels()
+    test_get_parent_node()
+    test_get_compactified_graph()
+    test_graph_string()
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(test_graph_visualization())
+    finally:
+        loop.close()


### PR DESCRIPTION
# Description
Added the ability to specify not to open mermaid in a browser when using the command line for graph visualization. This is done through the argument `--nobrowser` (can also use `-n`).

## Type of change
New feature.  All existing command line calls to ezmsg.core will produce the same output as before. 

## Change details
1. Added the argument `--nobrowser` (or `-n`), which when included alongside the argument `mermaid`, will print mermaid format graph string, but not open this in a browser.

## How Has This Been Tested?
Tested by running a pipeline and calling for mermaid output with and without `--nobrowser`. All ezmsg tests pass.