### PR TITLE
Throw error when trying to visualise graph with no graph server

### DIFF
--- a/src/ezmsg/core/graphserver.py
+++ b/src/ezmsg/core/graphserver.py
@@ -322,10 +322,10 @@ class GraphService(ServiceManager[GraphServer]):
             )
         try:
             dag: DAG = await self.dag()
-        except (ConnectionRefusedError, ConnectionResetError):
-            logger.info(
-                f"GraphServer not running @{self.address}, or host is refusing connections"
-            )
+        except (ConnectionRefusedError, ConnectionResetError) as e:
+            err_msg = f"GraphServer not running at address '{self.address}', or host is refusing connections"
+            logger.error(err_msg)
+            raise type(e)(err_msg) from e
         graph_connections = dag.graph.copy()
         if graph_connections is None or not graph_connections:
             return ""


### PR DESCRIPTION
Just a quick fix for a situation that arises when attempting to visualise a graph when there is no graph server running. After the fix we still throw but the error is more accurate to the problem and shows the full traceback. Importantly, the last line of the stack trace is more enlightening: `ConnectionRefusedError: GraphServer not running at address '127.0.0.1:25978', or host is refusing connections`

## Before
Currently if you run `uv run ezmsg mermaid` in the command line without a running graph server, you will get the unhelpful error and traceback:

```
2025-05-29 05:51:25.187 - pid: 58249 - MainThread - INFO - get_formatted_graph: GraphServer not running @127.0.0.1:25978, or host is refusing connections
Traceback (most recent call last):
  File "path/to/.venv/bin/ezmsg", line 8, in <module>
    sys.exit(cmdline())
             ^^^^^^^^^
  File "path/to/.venv/lib/python3.12/site-packages/ezmsg/core/command.py", line 92, in cmdline
    loop.run_until_complete(
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.12/asyncio/base_events.py", line 686, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "path/to/.venv/lib/python3.12/site-packages/ezmsg/core/command.py", line 166, in run_command
    graph_out = await graph_service.get_formatted_graph(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "path/to/.venv/lib/python3.12/site-packages/ezmsg/core/graphserver.py", line 329, in get_formatted_graph
    graph_connections = dag.graph.copy()
                        ^^^
UnboundLocalError: cannot access local variable 'dag' where it is not associated with a value
```

## After

Now, you get

```
2025-06-03 10:56:16.643 - pid: 64926 - MainThread - INFO - get_formatted_graph: GraphServer not running at address '127.0.0.1:25978', or host is refusing connections
Traceback (most recent call last):
  File "/path/to/ezmsg/src/ezmsg/core/graphserver.py", line 324, in get_formatted_graph
    dag: DAG = await self.dag()
               ^^^^^^^^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/graphserver.py", line 300, in dag
    reader, writer = await self.open_connection()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/graphserver.py", line 246, in open_connection
    reader, writer = await super().open_connection()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/server.py", line 154, in open_connection
    return await asyncio.open_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/streams.py", line 48, in open_connection
    transport, _ = await loop.create_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 1086, in create_connection
    raise exceptions[0]
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 1070, in create_connection
    sock = await self._connect_sock(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 974, in _connect_sock
    await self.sock_connect(sock, address)
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/selector_events.py", line 638, in sock_connect
    return await fut
           ^^^^^^^^^
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/selector_events.py", line 678, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 25978)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/path/to/ezmsg/.venv/bin/ezmsg", line 10, in <module>
    sys.exit(cmdline())
             ^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/command.py", line 92, in cmdline
    loop.run_until_complete(
  File "/path/to/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/command.py", line 166, in run_command
    graph_out = await graph_service.get_formatted_graph(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/ezmsg/src/ezmsg/core/graphserver.py", line 328, in get_formatted_graph
    raise type(e)(err_msg) from e
ConnectionRefusedError: GraphServer not running at address '127.0.0.1:25978', or host is refusing connections
```