### PR TITLE
Merge GraphServer and SHMServer

### DIFF
--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -17,7 +17,6 @@ from .stream import Stream
 from .unit import Unit, PROCESS_ATTR
 
 from .graphserver import GraphService
-from .shmserver import SHMService
 from .graphcontext import GraphContext
 from .backendprocess import (
     BackendProcess,
@@ -40,7 +39,6 @@ class ExecutionContext:
         self,
         processes: typing.List[typing.List[Unit]],
         graph_service: GraphService,
-        shm_service: SHMService,
         connections: typing.List[typing.Tuple[str, str]] = [],
         backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
     ) -> None:
@@ -60,7 +58,6 @@ class ExecutionContext:
                 self.start_barrier,
                 self.stop_barrier,
                 graph_service,
-                shm_service,
             )
             for process_units in processes
         ]
@@ -70,7 +67,6 @@ class ExecutionContext:
         cls,
         components: typing.Mapping[str, Component],
         graph_service: GraphService,
-        shm_service: SHMService,
         root_name: typing.Optional[str] = None,
         connections: typing.Optional[NetworkDefinition] = None,
         process_components: typing.Optional[typing.Collection[Component]] = None,
@@ -139,7 +135,6 @@ class ExecutionContext:
             return cls(
                 processes,
                 graph_service,
-                shm_service,
                 graph_connections,
                 backend_process,
             )
@@ -191,7 +186,6 @@ def run(
     # FIXME: This function is the last major re-implementation needed to make this
     # codebase more maintainable.
     graph_service = GraphService(graph_address)
-    shm_service = SHMService()
 
     if components is not None and isinstance(components, Component):
         components = {"SYSTEM": components}
@@ -206,7 +200,6 @@ def run(
         execution_context = ExecutionContext.setup(
             components,
             graph_service,
-            shm_service,
             root_name,
             connections,
             process_components,
@@ -219,7 +212,7 @@ def run(
 
         # FIXME: When done this way, we don't exit the graph_context on exception
         async def create_graph_context() -> GraphContext:
-            return await GraphContext(graph_service, shm_service).__aenter__()
+            return await GraphContext(graph_service).__aenter__()
 
         # FIXME: This sort of stuff should all be done in a separate async function...
         # Done this way, its ugly as hell and opens us up to a lot of issues with

--- a/src/ezmsg/core/backendprocess.py
+++ b/src/ezmsg/core/backendprocess.py
@@ -20,7 +20,6 @@ from .unit import Unit, TIMEIT_ATTR, SUBSCRIBES_ATTR, ZERO_COPY_ATTR
 
 from .graphcontext import GraphContext
 from .graphserver import GraphService
-from .shmserver import SHMService
 from .pubclient import Publisher
 from .subclient import Subscriber
 from .messagecache import MessageCache
@@ -65,7 +64,6 @@ class BackendProcess(Process):
     start_barrier: BarrierType
     stop_barrier: BarrierType
     graph_service: GraphService
-    shm_service: SHMService
 
     def __init__(
         self,
@@ -74,7 +72,6 @@ class BackendProcess(Process):
         start_barrier: BarrierType,
         stop_barrier: BarrierType,
         graph_service: GraphService,
-        shm_service: SHMService,
     ) -> None:
         super().__init__()
         self.units = units
@@ -82,7 +79,6 @@ class BackendProcess(Process):
         self.start_barrier = start_barrier
         self.stop_barrier = stop_barrier
         self.graph_service = graph_service
-        self.shm_service = shm_service
         self.task_finished_ev: Optional[threading.Event] = None
 
     def run(self) -> None:
@@ -103,7 +99,7 @@ class DefaultBackendProcess(BackendProcess):
 
     def process(self, loop: asyncio.AbstractEventLoop) -> None:
         main_func = None
-        context = GraphContext(self.graph_service, self.shm_service)
+        context = GraphContext(self.graph_service)
         coro_callables: Dict[str, Callable[[], Coroutine[Any, Any, None]]] = dict()
 
         try:

--- a/src/ezmsg/core/graphserver.py
+++ b/src/ezmsg/core/graphserver.py
@@ -22,8 +22,10 @@ from .netprotocol import (
     uint64_to_bytes,
     GRAPHSERVER_ADDR_ENV,
     GRAPHSERVER_PORT_DEFAULT,
+    DEFAULT_SHM_SIZE,
 )
 from .server import ServiceManager, ThreadedAsyncServer
+from .shm import SharedMemory, SHMContext, SHMInfo
 
 
 logger = logging.getLogger("ezmsg")
@@ -38,6 +40,9 @@ class GraphServer(ThreadedAsyncServer):
 
     graph: DAG
     clients: Dict[UUID, ClientInfo]
+    node: int
+    shms: Dict[str, SHMInfo]
+
     _client_tasks: Dict[UUID, "asyncio.Task[None]"]
     _command_lock: asyncio.Lock
 
@@ -47,10 +52,23 @@ class GraphServer(ThreadedAsyncServer):
         self.clients = dict()
         self._client_tasks = dict()
 
+        self.node = getnode()
+        self.shms = dict()
+
+
     async def setup(self) -> None:
         self._command_lock = asyncio.Lock()
 
     async def shutdown(self) -> None:
+        logger.info('shutting down')
+        for info in self.shms.values():
+            for lease_task in list(info.leases):
+                lease_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await lease_task
+            info.leases.clear()
+    
+        logger.info('leases released')
         for task in self._client_tasks.values():
             task.cancel()
             with suppress(asyncio.CancelledError):
@@ -78,88 +96,115 @@ class GraphServer(ThreadedAsyncServer):
                 self._shutdown.set()
                 await close_stream_writer(writer)
                 return
+            
+            elif req in [Command.SHM_CREATE.value, Command.SHM_ATTACH.value]:
+                info: Optional[SHMInfo] = None
 
-            # We only want to handle one command at a time
-            async with self._command_lock:
-                if req in [Command.SUBSCRIBE.value, Command.PUBLISH.value]:
-                    id = uuid1(node=node)
-                    writer.write(encode_str(str(id)))
+                if req == Command.SHM_CREATE.value:
+                    num_buffers = await read_int(reader)
+                    buf_size = await read_int(reader)
 
-                    pid = await read_int(reader)
-                    topic = await read_str(reader)
+                    # Create segment
+                    shm = SharedMemory(size=num_buffers * buf_size, create=True)
+                    shm.buf[:] = b"0" * len(shm.buf)  # Guarantee zeros
+                    shm.buf[0:8] = uint64_to_bytes(num_buffers)
+                    shm.buf[8:16] = uint64_to_bytes(buf_size)
+                    info = SHMInfo(shm)
+                    self.shms[shm.name] = info
+                    logger.debug(f"created {shm.name}")
 
-                    if req == Command.SUBSCRIBE.value:
-                        info = SubscriberInfo(id, writer, pid, topic)
-                        self.clients[id] = info
-                        self._client_tasks[id] = asyncio.create_task(
-                            self._handle_client(id, reader, writer)
-                        )
-                        iface = writer.transport.get_extra_info("sockname")[0]
-                        await self._notify_subscriber(info, iface)
+                elif req == Command.SHM_ATTACH.value:
+                    shm_name = await read_str(reader)
+                    info = self.shms.get(shm_name, None)
 
-                    elif req == Command.PUBLISH.value:
-                        address = await Address.from_stream(reader)
-                        info = PublisherInfo(id, writer, pid, topic, address)
-                        self.clients[id] = info
-                        self._client_tasks[id] = asyncio.create_task(
-                            self._handle_client(id, reader, writer)
-                        )
-                        iface = writer.transport.get_extra_info("peername")[0]
-                        for sub in self._downstream_subs(info.topic):
-                            await self._notify_subscriber(sub, iface)
-
-                    writer.write(Command.COMPLETE.value)
-                    await writer.drain()
+                if info is None:
                     return
 
-                elif req in [Command.CONNECT.value, Command.DISCONNECT.value]:
-                    from_topic = await read_str(reader)
-                    to_topic = await read_str(reader)
+                writer.write(Command.COMPLETE.value)
+                writer.write(encode_str(info.shm.name))
 
-                    cmd = self.graph.add_edge
-                    if req == Command.DISCONNECT.value:
-                        cmd = self.graph.remove_edge
+            else:
+                # We only want to handle one command at a time
+                async with self._command_lock:
+                    if req in [Command.SUBSCRIBE.value, Command.PUBLISH.value]:
+                        id = uuid1(node=node)
+                        writer.write(encode_str(str(id)))
 
-                    try:
-                        cmd(from_topic, to_topic)
-                        for sub in self._downstream_subs(to_topic):
-                            await self._notify_subscriber(sub)
+                        pid = await read_int(reader)
+                        topic = await read_str(reader)
+
+                        if req == Command.SUBSCRIBE.value:
+                            info = SubscriberInfo(id, writer, pid, topic)
+                            self.clients[id] = info
+                            self._client_tasks[id] = asyncio.create_task(
+                                self._handle_client(id, reader, writer)
+                            )
+                            iface = writer.transport.get_extra_info("sockname")[0]
+                            await self._notify_subscriber(info, iface)
+
+                        elif req == Command.PUBLISH.value:
+                            address = await Address.from_stream(reader)
+                            info = PublisherInfo(id, writer, pid, topic, address)
+                            self.clients[id] = info
+                            self._client_tasks[id] = asyncio.create_task(
+                                self._handle_client(id, reader, writer)
+                            )
+                            iface = writer.transport.get_extra_info("peername")[0]
+                            for sub in self._downstream_subs(info.topic):
+                                await self._notify_subscriber(sub, iface)
+
                         writer.write(Command.COMPLETE.value)
-                    except CyclicException:
-                        writer.write(Command.CYCLIC.value)
+                        await writer.drain()
+                        return
 
-                    await writer.drain()
+                    elif req in [Command.CONNECT.value, Command.DISCONNECT.value]:
+                        from_topic = await read_str(reader)
+                        to_topic = await read_str(reader)
 
-                    if req == Command.DISCONNECT.value:
-                        await close_stream_writer(writer)
+                        cmd = self.graph.add_edge
+                        if req == Command.DISCONNECT.value:
+                            cmd = self.graph.remove_edge
 
-                elif req == Command.SYNC.value:
-                    for pub in self._publishers():
                         try:
-                            async with pub.sync_writer() as pub_writer:
-                                pub_writer.write(Command.SYNC.value)
-                        except (ConnectionResetError, BrokenPipeError):
-                            continue
+                            cmd(from_topic, to_topic)
+                            for sub in self._downstream_subs(to_topic):
+                                await self._notify_subscriber(sub)
+                            writer.write(Command.COMPLETE.value)
+                        except CyclicException:
+                            writer.write(Command.CYCLIC.value)
 
-                    writer.write(Command.COMPLETE.value)
-                    await writer.drain()
+                        await writer.drain()
 
-                elif req == Command.PAUSE.value:
-                    for pub in self._publishers():
-                        pub.writer.write(Command.PAUSE.value)
+                        if req == Command.DISCONNECT.value:
+                            await close_stream_writer(writer)
 
-                elif req == Command.RESUME.value:
-                    for pub in self._publishers():
-                        pub.writer.write(Command.RESUME.value)
+                    elif req == Command.SYNC.value:
+                        for pub in self._publishers():
+                            try:
+                                async with pub.sync_writer() as pub_writer:
+                                    pub_writer.write(Command.SYNC.value)
+                            except (ConnectionResetError, BrokenPipeError):
+                                continue
 
-                elif req == Command.DAG.value:
-                    writer.write(Command.DAG.value)
-                    dag_bytes = pickle.dumps(self.graph)
-                    writer.write(uint64_to_bytes(len(dag_bytes)) + dag_bytes)
-                    writer.write(Command.COMPLETE.value)
+                        writer.write(Command.COMPLETE.value)
+                        await writer.drain()
 
-                else:
-                    logger.warn(f"GraphServer received unknown command {req}")
+                    elif req == Command.PAUSE.value:
+                        for pub in self._publishers():
+                            pub.writer.write(Command.PAUSE.value)
+
+                    elif req == Command.RESUME.value:
+                        for pub in self._publishers():
+                            pub.writer.write(Command.RESUME.value)
+
+                    elif req == Command.DAG.value:
+                        writer.write(Command.DAG.value)
+                        dag_bytes = pickle.dumps(self.graph)
+                        writer.write(uint64_to_bytes(len(dag_bytes)) + dag_bytes)
+                        writer.write(Command.COMPLETE.value)
+
+                    else:
+                        logger.warning(f"GraphServer received unknown command {req}")
 
         except (ConnectionResetError, BrokenPipeError):
             logger.debug("GraphServer connection fail mid-command")
@@ -345,3 +390,32 @@ class GraphService(ServiceManager[GraphServer]):
         formatted_graph = graph_string(graph_connections, fmt=fmt, direction=direction)
 
         return formatted_graph
+
+    async def create_shm(
+        self, num_buffers: int, buf_size: int = DEFAULT_SHM_SIZE
+    ) -> SHMContext:
+        reader, writer = await self.open_connection()
+        writer.write(Command.SHM_CREATE.value)
+        writer.write(uint64_to_bytes(num_buffers))
+        writer.write(uint64_to_bytes(buf_size))
+        await writer.drain()
+
+        response = await reader.read(1)
+        if response != Command.COMPLETE.value:
+            raise ValueError("Error creating SHM segment")
+
+        shm_name = await read_str(reader)
+        return SHMContext._create(shm_name, reader, writer)
+
+    async def attach_shm(self, name: str) -> SHMContext:
+        reader, writer = await self.open_connection()
+        writer.write(Command.SHM_ATTACH.value)
+        writer.write(encode_str(name))
+        await writer.drain()
+
+        response = await reader.read(1)
+        if response != Command.COMPLETE.value:
+            raise ValueError("Invalid SHM Name")
+
+        shm_name = await read_str(reader)
+        return SHMContext._create(shm_name, reader, writer)

--- a/src/ezmsg/core/messagecache.py
+++ b/src/ezmsg/core/messagecache.py
@@ -3,7 +3,7 @@ import logging
 from uuid import UUID
 from contextlib import contextmanager
 
-from .shmserver import SHMContext
+from .shm import SHMContext
 from .messagemarshal import MessageMarshal, UninitializedMemory
 
 from typing import Dict, Any, Optional, List, Generator

--- a/src/ezmsg/core/netprotocol.py
+++ b/src/ezmsg/core/netprotocol.py
@@ -18,10 +18,7 @@ DEFAULT_HOST = "127.0.0.1"
 GRAPHSERVER_ADDR_ENV = "EZMSG_GRAPHSERVER_ADDR"
 GRAPHSERVER_PORT_DEFAULT = 25978
 
-SHMSERVER_ADDR_ENV = "EZMSG_SHMSERVER_ADDR"
-SHMSERVER_PORT_DEFAULT = 25979
-
-RESERVED_PORTS = [GRAPHSERVER_PORT_DEFAULT, SHMSERVER_PORT_DEFAULT]
+RESERVED_PORTS = [GRAPHSERVER_PORT_DEFAULT]
 
 SERVER_PORT_START_ENV = "EZMSG_SERVER_PORT_START"
 SERVER_PORT_START_DEFAULT = 10000
@@ -139,6 +136,8 @@ async def close_server(server: Server):
 
 
 class Command(enum.Enum):
+
+    @staticmethod
     def _generate_next_value_(name, start, count, last_values) -> bytes:
         return count.to_bytes(1, BYTEORDER, signed=False)
 
@@ -162,7 +161,7 @@ class Command(enum.Enum):
     TX_TCP = enum.auto()
     RX_ACK = enum.auto()
 
-    # SHMServer Commands
+    # SHM Commands
     SHM_CREATE = enum.auto()
     SHM_ATTACH = enum.auto()
 

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -2,6 +2,8 @@ import pytest
 import asyncio
 import ezmsg.core as ez
 
+from ezmsg.core.graphserver import GraphService
+
 from multiprocessing import Process
 
 from typing import AsyncGenerator
@@ -105,12 +107,10 @@ class AttachEchoProcess(AttachTestProcess):
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="canonical port isn't always available")
 async def test_attach():
-    graph_service = ez.GraphService(address=ez.GraphService.default_address())
-    shm_service = ez.SHMService(address=ez.SHMService.default_address())
+    graph_service = GraphService(address=GraphService.default_address())
     graph_server = graph_service.create_server()
-    shm_server = shm_service.create_server()
 
-    async with ez.GraphContext(graph_service, shm_service):
+    async with ez.GraphContext(graph_service):
         settings = TransmitReceiveSettings()
 
         txrx_process = TransmitReceiveProcess(settings)
@@ -123,7 +123,6 @@ async def test_attach():
         txrx_process.join()
 
     graph_server.stop()
-    shm_server.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -1,27 +1,27 @@
 import asyncio
 import pytest
 
-from ezmsg.core.shmserver import SHMService
+from ezmsg.core.graphserver import GraphService
 
 
 @pytest.mark.asyncio
 async def test_invalid_name() -> None:
-    service = SHMService()
+    service = GraphService()
     server = service.create_server()
 
     with pytest.raises(ValueError):
-        await service.attach("JERRY")
+        await service.attach_shm("JERRY")
 
     server.stop()
 
 
 @pytest.mark.asyncio
 async def test_rw() -> None:
-    service = SHMService()
+    service = GraphService()
     server = service.create_server()
 
-    shm = await service.create(4, 2**16)
-    attach_shm = await service.attach(shm.name)
+    shm = await service.create_shm(4, 2**16)
+    attach_shm = await service.attach_shm(shm.name)
 
     content = b"HELLO"
     with attach_shm.buffer(0) as mem:
@@ -40,11 +40,11 @@ async def test_rw() -> None:
 
 @pytest.mark.asyncio
 async def test_shm_detach_order() -> None:
-    service = SHMService()
+    service = GraphService()
     server = service.create_server()
 
-    shm = await service.create(4, 2**16)
-    attach_shm = await service.attach(shm.name)
+    shm = await service.create_shm(4, 2**16)
+    attach_shm = await service.attach_shm(shm.name)
 
     content = b"HELLO"
     with attach_shm.buffer(0) as mem:
@@ -60,9 +60,8 @@ async def test_shm_detach_order() -> None:
     await shm.wait_closed()
 
     # Close created SHM first
-
-    shm = await service.create(4, 2**16)
-    attach_shm = await service.attach(shm.name)
+    shm = await service.create_shm(4, 2**16)
+    attach_shm = await service.attach_shm(shm.name)
 
     content = b"BONJOUR"
     with shm.buffer(0) as mem:
@@ -81,12 +80,12 @@ async def test_shm_detach_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shmserver_shutdown() -> None:
-    service = SHMService()
+async def test_shutdown() -> None:
+    service = GraphService()
     server = service.create_server()
 
-    shm = await service.create(4, 2**16)
-    attach_shm = await service.attach(shm.name)
+    shm = await service.create_shm(4, 2**16)
+    attach_shm = await service.attach_shm(shm.name)
 
     content = b"HELLO"
     with shm.buffer(0) as mem:
@@ -104,4 +103,4 @@ if __name__ == "__main__":
     asyncio.run(test_invalid_name())
     asyncio.run(test_rw())
     asyncio.run(test_shm_detach_order())
-    asyncio.run(test_shmserver_shutdown())
+    asyncio.run(test_shutdown())


### PR DESCRIPTION
Addresses #178 

This commit refactors the ezmsg core backend to merge the GraphServer and the SHMServer.  Rationale in #178; There is no SHMServer anymore, and the GraphServer manages SHM leases.  

Originally, SHMServer was separated from GraphServer because I had a mind to support distributed systems.  Now that GraphServer is coupled to SHM blocks, distributed systems that connect to a remote graph server will necessarily need to communicate via TCP, even if they're on the same machine.  In practice, I'm not sure this ever worked; and a more well-thought-out implementation is probably worth thinking through.  

This is a pretty significant refactor of the backend, so we might want to test this a bit more proactively.  