### PR TITLE
Moving ezmsg profiler from ezmsg-sigproc to ezmsg

### DIFF
--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -1,13 +1,14 @@
 import asyncio
-import logging
-import typing
 import enum
+import logging
+import os
+import typing
 
-from socket import socket
 from multiprocessing import Event, Barrier
 from multiprocessing.synchronize import Event as EventType
 from multiprocessing.synchronize import Barrier as BarrierType
 from multiprocessing.connection import wait, Connection
+from socket import socket
 
 from .netprotocol import DEFAULT_SHM_SIZE, AddressType
 
@@ -165,6 +166,7 @@ def run(
     backend_process: typing.Type[BackendProcess] = DefaultBackendProcess,
     graph_address: typing.Optional[AddressType] = None,
     force_single_process: bool = False,
+    profiler_log_name: str | None = None,
     **components_kwargs: Component,
 ) -> None:
     """
@@ -188,6 +190,7 @@ def run(
             This is necessary when running ``ezmsg`` in a notebook.
         components_kwargs:
     """
+    os.environ["EZMSG_PROFILER"] = profiler_log_name or "ezprofiler.log"
     # FIXME: This function is the last major re-implementation needed to make this
     # codebase more maintainable.
     graph_service = GraphService(graph_address)

--- a/src/ezmsg/util/profiler.py
+++ b/src/ezmsg/util/profiler.py
@@ -34,15 +34,16 @@ def _setup_logger(append: bool = False) -> logging.Logger:
         if append:
             with open(logpath) as f:
                 first_line = f.readline().rstrip()
-            if first_line == HEADER:
-                write_header = False
-            else:
-                # Remove the file if appending, but headers do not match
-                ezmsg_logger = logging.getLogger("ezmsg")
-                ezmsg_logger.warning(
-                    "Profiling header mismatch: please make sure to use the same version of ezmsg for all processes."
-                )
-                logpath.unlink()
+            if first_line:
+                if first_line == HEADER:
+                    write_header = False
+                else:
+                    # Remove the file if appending, but headers do not match
+                    ezmsg_logger = logging.getLogger("ezmsg")
+                    ezmsg_logger.warning(
+                        "Profiling header mismatch: please make sure to use the same version of ezmsg for all processes."
+                    )
+                    logpath.unlink()
         else:
             # Remove the file if not appending
             logpath.unlink()

--- a/src/ezmsg/util/profiler.py
+++ b/src/ezmsg/util/profiler.py
@@ -1,0 +1,182 @@
+import functools
+import logging
+import os
+from pathlib import Path
+import time
+import typing
+
+import ezmsg.core as ez
+
+
+HEADER = "Time,Source,Topic,SampleTime,PerfCounter,Elapsed"
+
+
+def get_logger_path() -> Path:
+    # Retrieve the logfile name from the environment variable
+    logfile = os.environ.get("EZMSG_PROFILER", None)
+
+    # Determine the log file path, defaulting to "ezprofiler.log" if not set
+    logpath = Path(logfile or "ezprofiler.log")
+
+    # If the log path is not absolute, prepend it with the user's home directory and ".ezmsg/profiler"
+    if not logpath.is_absolute():
+        logpath = Path.home() / ".ezmsg" / "profiler" / logpath
+
+    return logpath
+
+
+def _setup_logger(append: bool = False) -> logging.Logger:
+    logpath = get_logger_path()
+    logpath.parent.mkdir(parents=True, exist_ok=True)
+
+    write_header = True
+    if logpath.exists() and logpath.is_file():
+        if append:
+            with open(logpath) as f:
+                first_line = f.readline().rstrip()
+            if first_line == HEADER:
+                write_header = False
+            else:
+                # Remove the file if appending, but headers do not match
+                ezmsg_logger = logging.getLogger("ezmsg")
+                ezmsg_logger.warning(
+                    "Profiling header mismatch: please make sure to use the same version of ezmsg for all processes."
+                )
+                logpath.unlink()
+        else:
+            # Remove the file if not appending
+            logpath.unlink()
+
+    # Create a logger with the name "ezprofiler"
+    _logger = logging.getLogger("ezprofiler")
+
+    # Set the logger's level to EZMSG_LOGLEVEL env var value if it exists, otherwise INFO
+    _logger.setLevel(os.environ.get("EZMSG_LOGLEVEL", "INFO").upper())
+
+    # Create a file handler to write log messages to the log file
+    fh = logging.FileHandler(logpath)
+    fh.setLevel(logging.DEBUG)  # Set the file handler log level to DEBUG
+
+    # Add the file handler to the logger
+    _logger.addHandler(fh)
+
+    # Add the header if writing to new file or if header matched header in file.
+    if write_header:
+        _logger.debug(HEADER)
+
+    # Set the log message format
+    formatter = logging.Formatter(
+        "%(asctime)s,%(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"
+    )
+    fh.setFormatter(formatter)
+
+    return _logger
+
+
+logger = _setup_logger(append=True)
+
+
+def _process_obj(obj, trace_oldest: bool = True):
+    samp_time = None
+    if hasattr(obj, "axes") and ("time" in obj.axes or "win" in obj.axes):
+        axis = "win" if "win" in obj.axes else "time"
+        ax = obj.get_axis(axis)
+        len = obj.data.shape[obj.get_axis_idx(axis)]
+        if len > 0:
+            idx = 0 if trace_oldest else (len - 1)
+            if hasattr(ax, "data"):
+                samp_time = ax.data[idx]
+            else:
+                samp_time = ax.value(idx)
+            if ax == "win" and "time" in obj.axes:
+                if hasattr(obj.axes["time"], "data"):
+                    samp_time += obj.axes["time"].data[idx]
+                else:
+                    samp_time += obj.axes["time"].value(idx)
+    return samp_time
+
+
+def profile_method(trace_oldest: bool = True):
+    """
+    Decorator to profile a method by logging its execution time and other details.
+
+    Log messages are of the form:
+        module.classname (of caller), caller.address, start_time, stop_time, elapsed_time
+
+    :param trace_oldest: If True, trace the oldest sample time; otherwise, trace the newest.
+    :type trace_oldest: bool
+
+    :return: The decorated function with profiling enabled.
+    :rtype: Callable
+    """
+
+    def profiling_decorator(func: typing.Callable):
+        @functools.wraps(func)
+        def wrapped_func(caller, *args, **kwargs):
+            start = time.perf_counter()
+            res = func(caller, *args, **kwargs)
+            stop = time.perf_counter()
+            source = ".".join((caller.__class__.__module__, caller.__class__.__name__))
+            topic = f"{caller.address}"
+            samp_time = _process_obj(res, trace_oldest=trace_oldest)
+            logger.debug(
+                ",".join(
+                    [
+                        source,
+                        topic,
+                        f"{samp_time}",
+                        f"{stop}",
+                        f"{(stop - start) * 1e3:0.4f}",
+                    ]
+                )
+            )
+            return res
+
+        return wrapped_func if logger.level == logging.DEBUG else func
+
+    return profiling_decorator
+
+
+def profile_subpub(trace_oldest: bool = True):
+    """
+    Decorator to profile a subscriber-publisher method in an ezmsg Unit
+    by logging its execution time and other details.
+    Decorator to profile a subscriber-publisher method in an ezmsg Unit by logging its execution
+    time and other details.
+
+    Log messages are of the form:
+        module.classname (of unit), unit.address, start_time, stop_time, elapsed_time
+
+    :param trace_oldest: If True, trace the oldest sample time; otherwise, trace the newest.
+    :type trace_oldest: bool
+
+    :return: The decorated async task with profiling enabled.
+    :rtype: Callable
+    """
+
+    def profiling_decorator(func: typing.Callable):
+        @functools.wraps(func)
+        async def wrapped_task(unit: ez.Unit, msg: typing.Any = None):
+            source = ".".join((unit.__class__.__module__, unit.__class__.__name__))
+            topic = f"{unit.address}"
+            start = time.perf_counter()
+            async for stream, obj in func(unit, msg):
+                stop = time.perf_counter()
+                samp_time = _process_obj(obj, trace_oldest=trace_oldest)
+                logger.debug(
+                    ",".join(
+                        [
+                            source,
+                            topic,
+                            f"{samp_time}",
+                            f"{stop}",
+                            f"{(stop - start) * 1e3:0.4f}",
+                        ]
+                    )
+                )
+                start = stop
+                yield stream, obj
+
+        return wrapped_task if logger.level == logging.DEBUG else func
+
+    return profiling_decorator

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -102,6 +102,30 @@ def test_logger_append_header_mismatch(mock_logger_path):
         handler.close()
 
 
+def test_logger_append_no_header(mock_logger_path):
+    """Test that the logger correctly appends to the logfile if append=True and the header is correct."""
+
+    # Create a file with no header
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+
+    logger = _setup_logger(append=True)
+
+    # Assert that the file had the correct header logged
+    assert test_logpath.exists()
+    with open(test_logpath, "r") as f:
+        first_line = f.readline().strip()
+    assert first_line == HEADER
+
+    # Clean up the logger handlers
+    handlers = logger.handlers
+    for handler in handlers:
+        if isinstance(handler, logging.FileHandler):
+            logger.removeHandler(handler)
+            handler.close()
+
+
 def test_logger_append_header_match(mock_logger_path):
     """Test that the logger correctly appends to the logfile if append=True and the header is correct."""
     correct_header = HEADER

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,191 @@
+from datetime import datetime
+import os
+import pytest
+import logging
+from pathlib import Path
+from unittest.mock import patch
+from ezmsg.util.profiler import (
+    _setup_logger,
+    profile_method,
+    profile_subpub,
+    get_logger_path,
+    HEADER,
+)
+
+
+def test_logger_creation():
+    """Test that the ezprofiler logger is created when importing from ezmsg.util.profiler."""
+    logger_name = "ezprofiler"
+    assert logger_name in logging.Logger.manager.loggerDict
+    logger = logging.getLogger(logger_name)
+    assert logger.level == logging.INFO
+    assert len(logger.handlers) == 1
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.FileHandler)
+    assert handler.level == logging.DEBUG
+    assert Path(handler.baseFilename) == get_logger_path()
+
+    # Remove and close all handlers
+    logger.removeHandler(handler)
+    handler.close()
+
+
+@pytest.fixture
+def mock_env():
+    """Fixture to mock environment variables."""
+    with patch.dict(
+        os.environ, {"EZMSG_PROFILER": "test_profiler.log", "EZMSG_LOGLEVEL": "DEBUG"}
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_logger_path(mock_env):
+    """Fixture to mock the logger path."""
+    logpath = get_logger_path()
+    yield logpath
+
+
+def test_logger_not_append(mock_logger_path):
+    """Test that the logger creates a new file if append==False."""
+    some_text = "Some,Previous,Logger,Text"
+    correct_header = HEADER
+
+    # Create a file with some text
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(some_text + "\n")
+
+    logger = _setup_logger(append=False)
+    assert mock_logger_path.exists() and mock_logger_path.is_file()
+    assert logger.name == "ezprofiler"
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.FileHandler)
+    assert handler.level == logging.DEBUG
+    assert Path(handler.baseFilename) == test_logpath
+
+    with open(mock_logger_path, "r") as f:
+        first_line = f.readline().strip()
+    assert first_line == correct_header
+
+    # Clean up the logger file handler
+    logger.removeHandler(handler)
+    handler.close()
+
+
+def test_logger_append_header_mismatch(mock_logger_path):
+    """Test that the logger deletes the file if the header mismatches when append=True."""
+    incorrect_header = "Incorrect,Header,Format"
+    correct_header = HEADER
+
+    # Create a file with an incorrect header
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(incorrect_header + "\n")
+
+    logger = _setup_logger(append=True)
+
+    # Assert that the file was deleted and recreated
+    assert test_logpath.exists()
+    with open(test_logpath, "r") as f:
+        first_line = f.readline().strip()
+    assert first_line == correct_header
+
+    # Clean up the logger handlers
+    handlers = logger.handlers
+    for handler in handlers:
+        logger.removeHandler(handler)
+        handler.close()
+
+
+def test_logger_append_header_match(mock_logger_path):
+    """Test that the logger correctly appends to the logfile if append=True and the header is correct."""
+    correct_header = HEADER
+    next_line = "Some,New,Logger,Text"
+
+    # Create a file with the correct header
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(correct_header + "\n")
+        f.write(next_line + "\n")
+
+    logger = _setup_logger(append=True)
+    logger.debug("Some,Added,Logger,Text")
+
+    # Assert that the file was appended to
+    assert test_logpath.exists()
+    with open(test_logpath, "r") as f:
+        first_line = f.readline().strip()
+        second_line = f.readline().strip()
+        third_line = f.readline().strip()
+    assert first_line == correct_header
+    assert second_line == next_line
+    assert "Some,Added,Logger,Text" in third_line
+
+    # Clean up the logger handlers
+    handlers = logger.handlers
+    for handler in handlers:
+        if isinstance(handler, logging.FileHandler):
+            logger.removeHandler(handler)
+            handler.close()
+
+
+def test_profile_method_decorator():
+    """Test the profile_method decorator."""
+
+    class DummyClass:
+        address = "dummy_address"
+
+        @profile_method(trace_oldest=True)
+        def sample_method(self, x, y):
+            return x + y
+
+    instance = DummyClass()
+
+    with patch("ezmsg.util.profiler.logger") as mock_logger:
+        result = instance.sample_method(2, 3)
+        assert result == 5
+
+        # Assert the logger was called
+        mock_logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_profile_subpub_decorator(mock_logger_path):
+    """Test the profile_subpub decorator."""
+    test_logpath = mock_logger_path
+    _setup_logger()
+
+    class DummyUnit:
+        address = "dummy_address"
+
+        @profile_subpub(trace_oldest=True)
+        async def sample_subpub(self, msg):
+            yield "stream", msg
+
+    unit = DummyUnit()
+
+    async for stream, obj in unit.sample_subpub("message"):
+        # Assert the generator yields correctly
+        assert stream == "stream"
+        assert obj == "message"
+
+    # Assert the logger was called and printed in the correct format
+    with open(test_logpath, "r") as f:
+        f.readline()
+        second_line = f.readline().strip()
+    log_text = second_line.split(",")
+    assert len(log_text) == 6
+    datetime.strptime(
+        log_text[0], "%Y-%m-%dT%H:%M:%S%z"
+    )  # Will throw if format is incorrect
+    assert log_text[1].endswith("test_profiler.DummyUnit")
+    assert log_text[2] == "dummy_address"
+    assert log_text[3] == "None"
+    float(log_text[4])  # Will throw if not float
+    float(log_text[5])  # Will throw if not float

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -67,7 +67,8 @@ def test_local_system(toy_system_fixture, num_messages):
     system = toy_system_fixture(
         ToySystemSettings(num_msgs=num_messages, output_fn=test_filename)
     )
-    ez.run(SYSTEM=system)
+    ez.run(SYSTEM=system, profiler_log_name="test_profiler.log")
+    assert os.environ.get("EZMSG_PROFILER") == "test_profiler.log"
 
     results = []
     with open(test_filename, "r") as file:


### PR DESCRIPTION
# Description
Moved method profiling logic from `ezmsg-sigproc`. Hence, added the following profiling decorator methods:
- `@profile_method` for logging the execution time of a function, and
- `@profile_subpub` for logging the execution time of publisher/subscriber methods in ezmsg Units.

## Type of change
New feature (although this feature did live in `ezmsg-sigproc` previously). It is separate from other ezmsg logic, so it has no impact on current ezmsg use. 

Note: removal of this profiling logic from `ezmsg-sigproc` will occur in future PR. 

## Change details
1. Moved `profile_method` and `profile_subpub` methods from `ezmsg-sigproc`. (Moved `ezmsg/sigproc/util/profile.py` --> `ezmsg/core/util/profiler.py`.
2. Added parameter `profiler_log_name` to `run` method in `ezmsg/core/backend.py`. Giving it a string value sets the value of the environment variable `EZMSG_PROFILER`, which is used to determine the name of the profiler logfile. This parameter is optional defaulting to `None` which sets the environment variable to `ezprofiler.log`. 
3. Fixed erroneous logger warning when writing to an empty log file. It used to display the same warning as when it would detect the profiler logfile with different header line (which indicates different ezmsg version).
4. Changed the terms associated to this logic from *profile* to *profiler*. Eg. the logger is `ezprofiler` not ezprofile, the environment variable that sets its location is `EZMSG_PROFILER` not EZMSG_PROFILE etc. 
5. Added testing. Moved existing test from `ezmsg-sigproc` and added a test for the `run()` method parameter `profiler_log_name` and for the case of the profiler logger appending to an empty logfile.

### Changes affecting current usage
None. Though we expect to need to indicate migration of this logic when we remove it from sigproc. 

## How Has This Been Tested?
The profiler logic has been previously tested and these tests are found in `tests/test_profiler.py`. Additionally, in `test_local_system` of `tests/test_run.py`, we test the use of `profiler_log_name` parameter of `run` method. 

All ezmsg tests pass. Passes ruff formatter and linter checks.