### PR TITLE
Fix: GraphServer port no-longer lingers

### DIFF
--- a/src/ezmsg/core/netprotocol.py
+++ b/src/ezmsg/core/netprotocol.py
@@ -177,22 +177,29 @@ def create_socket(
     ignore_ports: typing.List[int] = RESERVED_PORTS,
 ) -> socket.socket:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     if host is None:
         host = DEFAULT_HOST
 
     if port is not None:
         sock.bind((host, port))
-        return sock
 
-    port = start_port
-    while port <= max_port:
-        if port not in ignore_ports:
-            try:
-                sock.bind((host, port))
-                return sock
-            except OSError:
-                pass
-        port += 1
+    else:
+        bound = False
+        port = start_port
+        while port <= max_port:
+            if port not in ignore_ports:
+                try:
+                    sock.bind((host, port))
+                    bound = True
+                    break
+                except OSError:
+                    pass
+            port += 1
 
-    raise IOError("Failed to bind socket; no free ports")
+        if not bound:
+            raise IOError("Failed to bind socket; no free ports")
+    
+    sock.setblocking(False)
+    return sock

--- a/src/ezmsg/core/server.py
+++ b/src/ezmsg/core/server.py
@@ -71,7 +71,8 @@ class ThreadedAsyncServer(Thread):
 
         async def monitor_shutdown() -> None:
             await self._loop.run_in_executor(None, self._shutdown.wait)
-            await close_server(server)
+            server.close()
+            await server.wait_closed()
 
         monitor_task = self._loop.create_task(monitor_shutdown())
 
@@ -82,9 +83,8 @@ class ThreadedAsyncServer(Thread):
 
         finally:
             await self.shutdown()
-            monitor_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await monitor_task
+            self._shutdown.set()
+            await monitor_task
 
     async def setup(self) -> None: ...
 


### PR DESCRIPTION
When (re)launching a GraphServer on the canonical port immediately after stopping the server, python throws `OSError: Address already in use`.  Setting `SO_REUSEADDR` addresses this issue.  

Additionally, we manually set the socket nonblocking which is required for asyncio. I think it actually does this internally when we pass it to `start_server` but at least we're explicit here.

Finally, we are much more explicit about server shutdown and we don't swallow exceptions anymore.