### PR TITLE
Fix: Input/OutputTopic/Relay for Collections

### DIFF
--- a/examples/ezmsg_configs.py
+++ b/examples/ezmsg_configs.py
@@ -82,8 +82,8 @@ class Listener(ez.Unit):
 
 
 class PassthroughCollection(ez.Collection):
-    INPUT = ez.InputStream(int)
-    OUTPUT = ez.OutputStream(int)
+    INPUT = ez.InputTopic(int)
+    OUTPUT = ez.OutputTopic(int)
 
     def network(self) -> ez.NetworkDefinition:
         return ((self.INPUT, self.OUTPUT),)
@@ -136,7 +136,7 @@ class NoPubNoSubSystem(ez.Collection):
 
 
 class PubNoSubCollection(ez.Collection):
-    OUTPUT = ez.OutputStream(int)
+    OUTPUT = ez.OutputTopic(int)
     GENERATE = Generator()
     LOG = DebugLog()
 
@@ -148,7 +148,7 @@ class PubNoSubCollection(ez.Collection):
 
 
 class SubNoPubCollection(ez.Collection):
-    INPUT = ez.InputStream(int)
+    INPUT = ez.InputTopic(int)
     LISTEN = Listener()
 
     def network(self) -> ez.NetworkDefinition:
@@ -175,7 +175,7 @@ class PubNoSubPassthroughCollection(ez.Collection):
     COLLECTION = PubNoSubCollection()
     PASSTHROUGH = PassthroughCollection()
 
-    OUTPUT = ez.OutputStream(int)
+    OUTPUT = ez.OutputTopic(int)
 
     def network(self) -> ez.NetworkDefinition:
         return (
@@ -188,7 +188,7 @@ class SubNoPubPassthroughCollection(ez.Collection):
     COLLECTION = SubNoPubCollection()
     PASSTHROUGH = PassthroughCollection()
 
-    INPUT = ez.InputStream(int)
+    INPUT = ez.InputTopic(int)
 
     def network(self) -> ez.NetworkDefinition:
         return (

--- a/examples/ezmsg_toy.py
+++ b/examples/ezmsg_toy.py
@@ -123,8 +123,8 @@ class ModifierCollection(ez.Collection):
     """This collection will subscribe to messages
     and append the most recent LFO output"""
 
-    INPUT = ez.InputStream(str)
-    OUTPUT = ez.OutputStream(str)
+    INPUT = ez.InputTopic(str)
+    OUTPUT = ez.OutputTopic(str)
 
     SIN = LFO()
     # SIN2 = LFO()

--- a/src/ezmsg/core/__init__.py
+++ b/src/ezmsg/core/__init__.py
@@ -14,6 +14,11 @@ __all__ = [
     "Settings",
     "Collection",
     "NetworkDefinition",
+    "Topic",
+    "InputTopic",
+    "OutputTopic",
+    "InputRelay",
+    "OutputRelay",
     "InputStream",
     "OutputStream",
     "Unit",
@@ -44,7 +49,15 @@ from .state import State
 from .settings import Settings
 from .collection import Collection, NetworkDefinition
 from .unit import Unit, task, publisher, subscriber, main, timeit, process, thread
-from .stream import InputStream, OutputStream
+from .stream import (
+    Topic,
+    InputTopic,
+    OutputTopic,
+    InputRelay,
+    OutputRelay,
+    InputStream,
+    OutputStream,
+)
 from .backend import run, GraphRunner, GraphRunnerStartError
 from .backendprocess import Complete, NormalTermination
 from .graphserver import GraphServer

--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -5,6 +5,7 @@ import enum
 import logging
 import os
 import signal
+from dataclasses import dataclass
 from threading import BrokenBarrierError
 from multiprocessing import Event, Barrier
 from multiprocessing.synchronize import Event as EventType
@@ -16,8 +17,9 @@ from .netprotocol import DEFAULT_SHM_SIZE, AddressType
 
 from .collection import Collection, NetworkDefinition
 from .component import Component
-from .stream import Stream
+from .stream import Stream, InputRelay, OutputRelay
 from .unit import Unit, PROCESS_ATTR
+from .relay import _CollectionRelayUnit, _RelaySettings
 
 from .graphserver import GraphService
 from .graphcontext import GraphContext
@@ -31,6 +33,16 @@ from .backendprocess import (
 from .util import either_dict_or_kwargs
 
 logger = logging.getLogger("ezmsg")
+
+
+@dataclass
+class _RelayBinding:
+    kind: str  # "input" or "output"
+    endpoint_topic: str
+    relay_in_topic: str
+    relay_out_topic: str
+    endpoint: InputRelay | OutputRelay
+    relay_unit: _CollectionRelayUnit
 
 
 class ExecutionContext:
@@ -95,22 +107,32 @@ class ExecutionContext:
         start_participant: bool = False,
     ) -> "ExecutionContext | None":
         graph_connections: list[tuple[str, str]] = []
+        relay_bindings: dict[str, _RelayBinding] = {}
 
         for name, component in components.items():
             component._set_name(name)
             component._set_location([root_name] if root_name is not None else [])
 
+        def normalize_topic(endpoint: Stream | str | enum.Enum, where: str) -> str:
+            if isinstance(endpoint, Stream):
+                return endpoint.address
+            if isinstance(endpoint, enum.Enum):
+                return endpoint.name
+            if isinstance(endpoint, str):
+                return endpoint
+            raise TypeError(
+                f"Invalid endpoint type in {where}: {type(endpoint)}. "
+                "Expected Stream, str, or Enum."
+            )
+
         if connections is not None:
             for from_topic, to_topic in connections:
-                if isinstance(from_topic, Stream):
-                    from_topic = from_topic.address
-                if isinstance(to_topic, Stream):
-                    to_topic = to_topic.address
-                if isinstance(to_topic, enum.Enum):
-                    to_topic = to_topic.name
-                if isinstance(from_topic, enum.Enum):
-                    from_topic = from_topic.name
-                graph_connections.append((from_topic, to_topic))
+                graph_connections.append(
+                    (
+                        normalize_topic(from_topic, "connections"),
+                        normalize_topic(to_topic, "connections"),
+                    )
+                )
 
         def crawl_components(
             component: Component, callback: Callable[[Component], None]
@@ -121,22 +143,114 @@ class ExecutionContext:
                 search += list(comp.components.values())
                 callback(comp)
 
+        def input_relay_settings(relay: InputRelay) -> _RelaySettings:
+            return _RelaySettings(
+                leaky=relay.leaky,
+                max_queue=relay.max_queue,
+                copy_on_forward=relay.copy_on_forward,
+            )
+
+        def output_relay_settings(relay: OutputRelay) -> _RelaySettings:
+            return _RelaySettings(
+                host=relay.host,
+                port=relay.port,
+                num_buffers=relay.num_buffers,
+                buf_size=relay.buf_size,
+                force_tcp=relay.force_tcp,
+                copy_on_forward=relay.copy_on_forward,
+            )
+
+        def add_collection_relay_units(comp: Component) -> None:
+            if not isinstance(comp, Collection):
+                return
+
+            for endpoint_name, endpoint in comp.streams.items():
+                if isinstance(endpoint, InputRelay):
+                    relay_name = f"__relay_in_{endpoint_name}"
+                    if relay_name in comp.components:
+                        raise ValueError(
+                            f"{comp.address} already defines component '{relay_name}'."
+                        )
+
+                    relay_unit = _CollectionRelayUnit(input_relay_settings(endpoint))
+                    relay_unit._set_name(relay_name)
+                    relay_unit._set_location(comp.location + [comp.name])
+                    comp.components[relay_name] = relay_unit
+                    setattr(comp, relay_name, relay_unit)
+
+                    relay_bindings[endpoint.address] = _RelayBinding(
+                        kind="input",
+                        endpoint_topic=endpoint.address,
+                        relay_in_topic=relay_unit.INPUT.address,
+                        relay_out_topic=relay_unit.OUTPUT.address,
+                        endpoint=endpoint,
+                        relay_unit=relay_unit,
+                    )
+
+                elif isinstance(endpoint, OutputRelay):
+                    relay_name = f"__relay_out_{endpoint_name}"
+                    if relay_name in comp.components:
+                        raise ValueError(
+                            f"{comp.address} already defines component '{relay_name}'."
+                        )
+
+                    relay_unit = _CollectionRelayUnit(output_relay_settings(endpoint))
+                    relay_unit._set_name(relay_name)
+                    relay_unit._set_location(comp.location + [comp.name])
+                    comp.components[relay_name] = relay_unit
+                    setattr(comp, relay_name, relay_unit)
+
+                    relay_bindings[endpoint.address] = _RelayBinding(
+                        kind="output",
+                        endpoint_topic=endpoint.address,
+                        relay_in_topic=relay_unit.INPUT.address,
+                        relay_out_topic=relay_unit.OUTPUT.address,
+                        endpoint=endpoint,
+                        relay_unit=relay_unit,
+                    )
+
+        for component in components.values():
+            if isinstance(component, Collection):
+                crawl_components(component, add_collection_relay_units)
+
         def gather_edges(comp: Component):
             if isinstance(comp, Collection):
                 for from_stream, to_stream in comp.network():
-                    if isinstance(from_stream, Stream):
-                        from_stream = from_stream.address
-                    if isinstance(to_stream, Stream):
-                        to_stream = to_stream.address
-                    if isinstance(to_stream, enum.Enum):
-                        to_stream = to_stream.name
-                    if isinstance(from_stream, enum.Enum):
-                        from_stream = from_stream.name
-                    graph_connections.append((from_stream, to_stream))
+                    graph_connections.append(
+                        (
+                            normalize_topic(from_stream, f"{comp.address}.network"),
+                            normalize_topic(to_stream, f"{comp.address}.network"),
+                        )
+                    )
 
         for component in components.values():
             if isinstance(component, Collection):
                 crawl_components(component, gather_edges)
+
+        if relay_bindings:
+            rewritten_connections: list[tuple[str, str]] = []
+            for from_topic, to_topic in graph_connections:
+                to_binding = relay_bindings.get(to_topic, None)
+                if to_binding is not None and to_binding.kind == "output":
+                    to_topic = to_binding.relay_in_topic
+
+                from_binding = relay_bindings.get(from_topic, None)
+                if from_binding is not None and from_binding.kind == "input":
+                    from_topic = from_binding.relay_out_topic
+
+                rewritten_connections.append((from_topic, to_topic))
+
+            for binding in relay_bindings.values():
+                if binding.kind == "input":
+                    rewritten_connections.append(
+                        (binding.endpoint_topic, binding.relay_in_topic)
+                    )
+                else:
+                    rewritten_connections.append(
+                        (binding.relay_out_topic, binding.endpoint_topic)
+                    )
+
+            graph_connections = rewritten_connections
 
         processes = collect_processes(components.values(), process_components)
 
@@ -148,6 +262,14 @@ class ExecutionContext:
                         comp.configure()
 
                 crawl_components(component, configure_collections)
+
+        for binding in relay_bindings.values():
+            if isinstance(binding.endpoint, InputRelay):
+                binding.relay_unit.apply_settings(input_relay_settings(binding.endpoint))
+            elif isinstance(binding.endpoint, OutputRelay):
+                binding.relay_unit.apply_settings(
+                    output_relay_settings(binding.endpoint)
+                )
 
         if force_single_process:
             processes = [[u for pu in processes for u in pu]]

--- a/src/ezmsg/core/collection.py
+++ b/src/ezmsg/core/collection.py
@@ -2,8 +2,9 @@ from collections.abc import Iterable
 from collections.abc import Collection as AbstractCollection
 import typing
 from copy import deepcopy
+import warnings
 
-from .stream import Stream
+from .stream import Stream, InputStream, OutputStream
 from .component import ComponentMeta, Component
 from .settings import Settings
 
@@ -34,6 +35,16 @@ class CollectionMeta(ComponentMeta):
             if isinstance(field_value, Component):
                 field_value._set_name(field_name)
                 cls.__components__[field_name] = field_value
+            elif isinstance(field_value, (InputStream, OutputStream)):
+                warnings.warn(
+                    f"{name}.{field_name} uses {type(field_value).__name__} as a "
+                    "Collection boundary endpoint. This behavior is deprecated and "
+                    "will change in a future release. Use InputTopic / OutputTopic "
+                    "for zero-overhead topic shortcuts, or InputRelay / OutputRelay "
+                    "for explicit boundary republishers.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
 
 
 class Collection(Component, metaclass=CollectionMeta):

--- a/src/ezmsg/core/relay.py
+++ b/src/ezmsg/core/relay.py
@@ -1,0 +1,42 @@
+from copy import deepcopy
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from .settings import Settings
+from .netprotocol import DEFAULT_SHM_SIZE
+from .stream import InputStream, OutputStream
+from .unit import Unit, publisher, subscriber
+
+
+class _RelaySettings(Settings):
+    leaky: bool = False
+    max_queue: int | None = None
+    host: str | None = None
+    port: int | None = None
+    num_buffers: int = 32
+    buf_size: int = DEFAULT_SHM_SIZE
+    force_tcp: bool = False
+    copy_on_forward: bool = True
+
+
+class _CollectionRelayUnit(Unit):
+    SETTINGS = _RelaySettings
+
+    INPUT = InputStream(Any)
+    OUTPUT = OutputStream(Any)
+
+    async def initialize(self) -> None:
+        self.INPUT.leaky = self.SETTINGS.leaky
+        self.INPUT.max_queue = self.SETTINGS.max_queue
+        self.OUTPUT.host = self.SETTINGS.host
+        self.OUTPUT.port = self.SETTINGS.port
+        self.OUTPUT.num_buffers = self.SETTINGS.num_buffers
+        self.OUTPUT.buf_size = self.SETTINGS.buf_size
+        self.OUTPUT.force_tcp = self.SETTINGS.force_tcp
+
+    @subscriber(INPUT)
+    @publisher(OUTPUT)
+    async def relay(self, msg: Any) -> AsyncGenerator:
+        if self.SETTINGS.copy_on_forward:
+            msg = deepcopy(msg)
+        yield self.OUTPUT, msg

--- a/src/ezmsg/core/stream.py
+++ b/src/ezmsg/core/stream.py
@@ -26,6 +26,110 @@ class Stream(Addressable):
         return f"Stream:{_addr}[{self.msg_type.__name__}]"
 
 
+class Topic(Stream):
+    """
+    Graph endpoint metadata for Collection boundaries and graph wiring.
+
+    Topics represent named DAG nodes only. Unlike InputStream / OutputStream,
+    they do not directly configure Subscriber / Publisher transport behavior.
+    """
+
+    def __repr__(self) -> str:
+        return f"Topic{super().__repr__()}()"
+
+
+class InputTopic(Topic):
+    """
+    Directional alias for a Collection input topic.
+    """
+
+    def __repr__(self) -> str:
+        return f"Input{super().__repr__()}"
+
+
+class OutputTopic(Topic):
+    """
+    Directional alias for a Collection output topic.
+    """
+
+    def __repr__(self) -> str:
+        return f"Output{super().__repr__()}"
+
+
+class InputRelay(InputTopic):
+    """
+    Collection input boundary that materializes an internal relay subscriber/publisher.
+
+    This enables subscriber-side behavior (e.g., leaky reception) on the boundary.
+    """
+
+    leaky: bool
+    max_queue: int | None
+    copy_on_forward: bool
+
+    def __init__(
+        self,
+        msg_type: Any,
+        leaky: bool = False,
+        max_queue: int | None = None,
+        copy_on_forward: bool = True,
+    ) -> None:
+        super().__init__(msg_type)
+        if max_queue is not None and max_queue <= 0:
+            raise ValueError("max_queue must be positive")
+        self.leaky = leaky
+        self.max_queue = max_queue
+        self.copy_on_forward = copy_on_forward
+
+    def __repr__(self) -> str:
+        base = f"InputRelay{Stream.__repr__(self)}"
+        return (
+            f"{base}(leaky={self.leaky}, max_queue={self.max_queue}, "
+            f"copy_on_forward={self.copy_on_forward})"
+        )
+
+
+class OutputRelay(OutputTopic):
+    """
+    Collection output boundary that materializes an internal relay subscriber/publisher.
+
+    This enables publisher-side behavior (e.g., custom transport buffer settings)
+    on the boundary.
+    """
+
+    host: str | None
+    port: int | None
+    num_buffers: int
+    buf_size: int
+    force_tcp: bool
+    copy_on_forward: bool
+
+    def __init__(
+        self,
+        msg_type: Any,
+        host: str | None = None,
+        port: int | None = None,
+        num_buffers: int = 32,
+        buf_size: int = DEFAULT_SHM_SIZE,
+        force_tcp: bool = False,
+        copy_on_forward: bool = True,
+    ) -> None:
+        super().__init__(msg_type)
+        self.host = host
+        self.port = port
+        self.num_buffers = num_buffers
+        self.buf_size = buf_size
+        self.force_tcp = force_tcp
+        self.copy_on_forward = copy_on_forward
+
+    def __repr__(self) -> str:
+        base = f"OutputRelay{Stream.__repr__(self)}"
+        return (
+            f"{base}(num_buffers={self.num_buffers}, force_tcp={self.force_tcp}, "
+            f"copy_on_forward={self.copy_on_forward})"
+        )
+
+
 class InputStream(Stream):
     """
     Can be added to any Component as a member variable. Methods may subscribe to it.

--- a/src/ezmsg/core/unit.py
+++ b/src/ezmsg/core/unit.py
@@ -2,7 +2,7 @@ import time
 import inspect
 import functools
 import warnings
-from .stream import InputStream, OutputStream
+from .stream import InputStream, OutputStream, Topic
 from .component import ComponentMeta, Component
 from .settings import Settings
 
@@ -55,6 +55,12 @@ class UnitMeta(ComponentMeta):
                     cls.__threads__[thread_name] = thread
 
         for field_name, field_value in fields.items():
+            if isinstance(field_value, Topic):
+                raise TypeError(
+                    f"{name}.{field_name} is a {type(field_value).__name__}. "
+                    "Units may only declare InputStream / OutputStream endpoints. "
+                    "Use Topic / Relay endpoints on Collections only."
+                )
             if callable(field_value):
                 if hasattr(field_value, TASK_ATTR):
                     cls.__tasks__[field_name] = field_value

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,156 @@
+import pytest
+
+import ezmsg.core as ez
+
+from ezmsg.core.backend import ExecutionContext
+
+
+@pytest.mark.parametrize(
+    "endpoint_factory",
+    [
+        lambda: ez.Topic(int),
+        lambda: ez.InputTopic(int),
+        lambda: ez.OutputTopic(int),
+        lambda: ez.InputRelay(int),
+        lambda: ez.OutputRelay(int),
+    ],
+)
+def test_unit_rejects_topic_endpoints(endpoint_factory):
+    with pytest.raises(TypeError, match="Units may only declare InputStream"):
+
+        class BadUnit(ez.Unit):
+            ENDPOINT = endpoint_factory()
+
+
+def test_collection_stream_endpoint_warns_futurewarning():
+    with pytest.warns(FutureWarning, match="deprecated"):
+
+        class LegacyCollection(ez.Collection):
+            INPUT = ez.InputStream(int)
+
+
+class _Source(ez.Unit):
+    OUTPUT = ez.OutputStream(int)
+
+
+class _Sink(ez.Unit):
+    INPUT = ez.InputStream(int)
+
+
+class _TopicPassthrough(ez.Collection):
+    IN = ez.InputTopic(int)
+    OUT = ez.OutputTopic(int)
+
+    def network(self) -> ez.NetworkDefinition:
+        return ((self.IN, self.OUT),)
+
+
+class _RelayInputPassthrough(ez.Collection):
+    IN = ez.InputRelay(int, leaky=False, max_queue=None, copy_on_forward=True)
+    OUT = ez.OutputTopic(int)
+
+    def configure(self) -> None:
+        self.IN.leaky = True
+        self.IN.max_queue = 7
+
+    def network(self) -> ez.NetworkDefinition:
+        return ((self.IN, self.OUT),)
+
+
+class _RelayOutputPassthrough(ez.Collection):
+    IN = ez.InputTopic(int)
+    OUT = ez.OutputRelay(int, num_buffers=16, force_tcp=True, copy_on_forward=False)
+
+    def configure(self) -> None:
+        self.OUT.num_buffers = 8
+
+    def network(self) -> ez.NetworkDefinition:
+        return ((self.IN, self.OUT),)
+
+
+class _TopicSystem(ez.Collection):
+    SOURCE = _Source()
+    PASSTHROUGH = _TopicPassthrough()
+    SINK = _Sink()
+
+    def network(self) -> ez.NetworkDefinition:
+        return (
+            (self.SOURCE.OUTPUT, self.PASSTHROUGH.IN),
+            (self.PASSTHROUGH.OUT, self.SINK.INPUT),
+        )
+
+
+class _InputRelaySystem(ez.Collection):
+    SOURCE = _Source()
+    PASSTHROUGH = _RelayInputPassthrough()
+    SINK = _Sink()
+
+    def network(self) -> ez.NetworkDefinition:
+        return (
+            (self.SOURCE.OUTPUT, self.PASSTHROUGH.IN),
+            (self.PASSTHROUGH.OUT, self.SINK.INPUT),
+        )
+
+
+class _OutputRelaySystem(ez.Collection):
+    SOURCE = _Source()
+    PASSTHROUGH = _RelayOutputPassthrough()
+    SINK = _Sink()
+
+    def network(self) -> ez.NetworkDefinition:
+        return (
+            (self.SOURCE.OUTPUT, self.PASSTHROUGH.IN),
+            (self.PASSTHROUGH.OUT, self.SINK.INPUT),
+        )
+
+
+def test_input_output_topics_behave_as_shortcuts():
+    system = _TopicSystem()
+    ctx = ExecutionContext.setup({"SYSTEM": system})
+    assert ctx is not None
+    assert (system.SOURCE.OUTPUT.address, system.PASSTHROUGH.IN.address) in ctx.connections
+    assert (system.PASSTHROUGH.IN.address, system.PASSTHROUGH.OUT.address) in ctx.connections
+    assert (system.PASSTHROUGH.OUT.address, system.SINK.INPUT.address) in ctx.connections
+
+
+def test_input_relay_rewrites_edges_and_syncs_settings():
+    system = _InputRelaySystem()
+    ctx = ExecutionContext.setup({"SYSTEM": system})
+    assert ctx is not None
+
+    relay = system.PASSTHROUGH.components["__relay_in_IN"]
+    source = system.SOURCE.OUTPUT.address
+    endpoint_in = system.PASSTHROUGH.IN.address
+    endpoint_out = system.PASSTHROUGH.OUT.address
+    sink = system.SINK.INPUT.address
+
+    assert (source, endpoint_in) in ctx.connections
+    assert (endpoint_in, relay.INPUT.address) in ctx.connections
+    assert (relay.OUTPUT.address, endpoint_out) in ctx.connections
+    assert (endpoint_out, sink) in ctx.connections
+    assert (endpoint_in, endpoint_out) not in ctx.connections
+
+    assert relay.SETTINGS.leaky is True
+    assert relay.SETTINGS.max_queue == 7
+    assert relay.SETTINGS.copy_on_forward is True
+
+
+def test_output_relay_rewrites_edges_and_syncs_settings():
+    system = _OutputRelaySystem()
+    ctx = ExecutionContext.setup({"SYSTEM": system})
+    assert ctx is not None
+
+    relay = system.PASSTHROUGH.components["__relay_out_OUT"]
+    source = system.SOURCE.OUTPUT.address
+    endpoint_in = system.PASSTHROUGH.IN.address
+    endpoint_out = system.PASSTHROUGH.OUT.address
+    sink = system.SINK.INPUT.address
+
+    assert (source, endpoint_in) in ctx.connections
+    assert (endpoint_in, relay.INPUT.address) in ctx.connections
+    assert (relay.OUTPUT.address, endpoint_out) in ctx.connections
+    assert (endpoint_out, sink) in ctx.connections
+
+    assert relay.SETTINGS.num_buffers == 8
+    assert relay.SETTINGS.force_tcp is True
+    assert relay.SETTINGS.copy_on_forward is False


### PR DESCRIPTION
Closes #11 

This PR introduces new high-level graph endpoint types for Collections:

- `Topic`
- `InputTopic`
- `OutputTopic`
- `InputRelay`
- `OutputRelay`

The goal is to separate:

- **zero-overhead graph topic shortcuts** (`Topic` / `InputTopic` / `OutputTopic`)
- **explicit boundary republishers with pub/sub behavior** (`InputRelay` / `OutputRelay`)

This preserves current behavior for existing systems while giving users a clear, explicit way to opt into boundary subscriber/publisher semantics.

## Motivation

Historically, Collection boundary endpoints were often declared as `InputStream` / `OutputStream`, even though in many cases they functioned only as graph topic shortcut nodes (not true pub/sub clients).

This conflates two concepts:

- graph-level topic wiring
- runtime subscriber/publisher configuration

The new API makes that distinction explicit and backward-compatible.

## What Changed

### 1) New endpoint classes

Added in `src/ezmsg/core/stream.py`:

- `Topic(Stream)`: non-directional graph endpoint metadata.
- `InputTopic(Topic)`: directional alias for Collection inputs.
- `OutputTopic(Topic)`: directional alias for Collection outputs.
- `InputRelay(InputTopic)`: Collection input boundary with subscriber-side relay options:
  - `leaky`
  - `max_queue`
  - `copy_on_forward` (default `True`)
- `OutputRelay(OutputTopic)`: Collection output boundary with publisher-side relay options:
  - `host`
  - `port`
  - `num_buffers`
  - `buf_size`
  - `force_tcp`
  - `copy_on_forward` (default `True`)

### 2) Internal relay unit implementation

Added `src/ezmsg/core/relay.py`:

- `_CollectionRelayUnit` (internal)
- `_RelaySettings` (internal)

Behavior:

- materialized relays are explicit subscriber+publisher hops
- relay forwarding defaults to `deepcopy(msg)` (`copy_on_forward=True`) for safety under zero-copy semantics
- advanced users can disable copying (`copy_on_forward=False`) when appropriate

### 3) Unit restrictions (hard error)

Updated `src/ezmsg/core/unit.py`:

- Units now raise `TypeError` at class creation if they declare `Topic`/`InputTopic`/`OutputTopic`/`InputRelay`/`OutputRelay`.
- Units must continue using `InputStream` / `OutputStream`.

### 4) Collection legacy stream warning

Updated `src/ezmsg/core/collection.py`:

- `CollectionMeta` emits `FutureWarning` when a Collection declares boundary `InputStream`/`OutputStream`.
- Legacy behavior remains functional (no runtime break).

### 5) Relay graph materialization/rewrite in setup

Updated `src/ezmsg/core/backend.py` (`ExecutionContext.setup`):

- detects `InputRelay` / `OutputRelay` endpoints in Collections
- injects hidden internal relay units into the containing Collection
- rewrites graph edges to route through relay units while preserving public Collection boundary topic names
- synchronizes relay settings **after** `Collection.configure()` so configure-time edits to relay options are honored
- normalized endpoint conversion now validates endpoint types (`Stream`, `str`, `Enum`)

### 6) Public exports

Updated `src/ezmsg/core/__init__.py`:

- exported: `Topic`, `InputTopic`, `OutputTopic`, `InputRelay`, `OutputRelay`

## Backward Compatibility

- Existing Collection `InputStream`/`OutputStream` usage still works.
- Existing systems continue to run without behavior change in that legacy path.
- Users receive `FutureWarning` encouraging migration:
  - use `InputTopic`/`OutputTopic` for zero-overhead topic shortcuts
  - use `InputRelay`/`OutputRelay` for explicit boundary republishers

## Zero-Copy Safety

Given high-level `@ez.subscriber` zero-copy semantics, relays default to safe forwarding:

- `copy_on_forward=True` (default): deep-copies inbound message before republish
- `copy_on_forward=False`: republish same object reference (advanced/unsafe mode)
    - Note that currently, `leaky` subscribers already deepcopy (which could change in the future), so it may be completely rational to provide `leaky=True, copy_on_forward=False`.

This is intended to prevent aliasing/corruption hazards when relaying cached/shared-memory-backed messages.

## Tests Added

New file: `tests/test_topics.py`

Covers:

- Unit rejects all topic/relay endpoint types (`TypeError`)
- Collection legacy stream endpoint emits `FutureWarning`
- `InputTopic`/`OutputTopic` preserve topic-shortcut behavior
- `InputRelay` rewrites edges correctly and syncs configure-time settings
- `OutputRelay` rewrites edges correctly and syncs configure-time settings
