### PR TITLE
Fix: Timing-related issue with clean-shutdown tests.

### DIFF
--- a/tests/shutdown_runner.py
+++ b/tests/shutdown_runner.py
@@ -8,11 +8,14 @@ import sys
 
 import ezmsg.core as ez
 
+STARTED = threading.Event()
+
 
 class BlockingDiskIO(ez.Unit):
     @ez.task
     async def blocked_read(self) -> None:
         # Cross-platform "hung disk I/O" simulation.
+        STARTED.set()
         event = threading.Event()
         self._event = event
         await asyncio.shield(asyncio.to_thread(event.wait))
@@ -21,6 +24,7 @@ class BlockingDiskIO(ez.Unit):
 class BlockingSocket(ez.Unit):
     @ez.task
     async def blocked_recv(self) -> None:
+        STARTED.set()
         sock_r, sock_w = socket.socketpair()
         sock_r.setblocking(True)
         sock_w.setblocking(True)
@@ -33,6 +37,7 @@ class BlockingSocket(ez.Unit):
 class ExplodeOnCancel(ez.Unit):
     @ez.task
     async def explode(self) -> None:
+        STARTED.set()
         try:
             while True:
                 await asyncio.sleep(1.0)
@@ -43,6 +48,7 @@ class ExplodeOnCancel(ez.Unit):
 class StubbornTask(ez.Unit):
     @ez.task
     async def ignore_cancel(self) -> None:
+        STARTED.set()
         while True:
             try:
                 await asyncio.sleep(1.0)
@@ -84,7 +90,7 @@ def main() -> None:
 
     def _watch_ready() -> None:
         while not done.is_set():
-            if runner.running:
+            if runner.running and STARTED.is_set():
                 _emit_ready()
                 return
             time.sleep(0.01)


### PR DESCRIPTION
## Summary

This PR fixes a timing race in shutdown test orchestration that could cause inconsistent return codes in `test_shutdown_exception_on_cancel`.

## Problem

`tests/shutdown_runner.py` emitted `READY` as soon as `runner.running` became `True`.  
In some runs, that happened before the target task actually entered its execution loop.

As a result:
- SIGINT could be sent too early
- cancellation-path behavior under test might not be exercised
- subprocess could exit `0` instead of a SIGINT code (`130` / `-SIGINT`)

## Changes

Updated `tests/shutdown_runner.py` to synchronize readiness with actual task start:

- Added a module-scoped `STARTED` event.
- Set `STARTED` at entry of each task used by shutdown tests:
  - `BlockingDiskIO.blocked_read`
  - `BlockingSocket.blocked_recv`
  - `ExplodeOnCancel.explode`
  - `StubbornTask.ignore_cancel`
- Changed READY gate in watcher thread from:
  - `runner.running`
  to:
  - `runner.running and STARTED.is_set()`

## Why this fix

This ensures signal injection only starts after the target task is truly active, making shutdown behavior tests deterministic and aligned with the scenario they are intended to validate.

## Testing

- `pytest tests/test_clean_shutdown.py::test_shutdown_exception_on_cancel -q`
- `pytest tests/test_clean_shutdown.py -q`

Both pass consistently with this change.
