### PR TITLE
Fix: _startup only true once system is at steady state

### DIFF
--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -667,7 +667,6 @@ class GraphRunner:
             force_single_process=self._force_single_process, wait_for_ready=False
         ):
             return
-        self._started = True
         self._run_main_process()
 
     def _initialize(self, force_single_process: bool, wait_for_ready: bool) -> bool:
@@ -767,11 +766,12 @@ class GraphRunner:
         if self._execution_context is None or self._loop is None:
             return
         self._main_process = self._execution_context.processes[0]
-        self._start_processes(self._execution_context.processes[1:])
 
         interrupts = 0
         forced_sigint = False
         try:
+            self._start_processes(self._execution_context.processes[1:])
+            self._started = True
             self._main_process.process(self._loop)
             self._join_spawned_processes()
             logger.info("All processes exited normally")


### PR DESCRIPTION
## Summary

This PR fixes a small readiness race in `GraphRunner.run_blocking()` that could cause sporadic shutdown-test failures.

Previously, `run_blocking()` set `GraphRunner.running` to `True` before entering the main-process execution path. That meant external watchers could observe the runner as "running" and send `SIGINT` before the `KeyboardInterrupt` handling in `_run_main_process()` was actually active.

This change moves the `_started = True` transition into `_run_main_process()` immediately before backend execution begins. As a result, `GraphRunner.running` now becomes visible slightly later, but with a more accurate meaning for the blocking-run path.

## Changes

- Move the `run_blocking()` `_started = True` transition into `_run_main_process()`
- Leave the test assertion strict: the shutdown example is still expected to exit cleanly after a single `SIGINT`
