### PR TITLE
Feature: Trace mode in `ezmsg perf hotpath`

### DIFF
--- a/src/ezmsg/util/perf/ab.py
+++ b/src/ezmsg/util/perf/ab.py
@@ -83,6 +83,7 @@ def build_hotpath_command(
     apis: list[str],
     num_buffers: int,
     quiet: bool,
+    trace: bool = False,
 ) -> list[str]:
     cmd = [
         str(python),
@@ -104,6 +105,8 @@ def build_hotpath_command(
         *apis,
         *_hotpath_json_arg(output_path),
     ]
+    if trace:
+        cmd.append("--trace")
     if quiet:
         cmd.append("--quiet")
     return cmd

--- a/src/ezmsg/util/perf/hotpath.py
+++ b/src/ezmsg/util/perf/hotpath.py
@@ -19,6 +19,8 @@ from uuid import uuid4
 import ezmsg.core as ez
 
 from ezmsg.core.graphserver import GraphServer
+from ezmsg.core.graphmeta import ProfilingTraceControl
+from ezmsg.core.processclient import ProcessControlClient
 
 from .util import coef_var, median_of_means, stable_perf
 
@@ -28,6 +30,8 @@ TransportName = Literal["local", "shm", "tcp"]
 DEFAULT_APIS: tuple[ApiName, ...] = ("async",)
 DEFAULT_TRANSPORTS: tuple[TransportName, ...] = ("local", "shm", "tcp")
 DEFAULT_PAYLOAD_SIZES = (64, 4096)
+DEFAULT_TRACE_METRICS = ["publish_delta_ns", "lease_time_ns", "user_span_ns"]
+TRACE_UNIT_ADDRESS = "EZMSG/PERF/HOTPATH"
 
 
 def _supports_same_process_transport_selection() -> bool:
@@ -64,12 +68,13 @@ class HotPathCase:
     transport: TransportName
     payload_size: int
     num_buffers: int
+    trace: bool = False
 
     @property
     def case_id(self) -> str:
         return (
             f"{self.api}/{self.transport}/payload={self.payload_size}"
-            f"/buffers={self.num_buffers}"
+            f"/buffers={self.num_buffers}/trace={str(self.trace).lower()}"
         )
 
 
@@ -124,6 +129,7 @@ def build_cases(
     transports: list[str],
     payload_sizes: list[int],
     num_buffers: int,
+    trace: bool = False,
 ) -> list[HotPathCase]:
     cases = [
         HotPathCase(
@@ -131,6 +137,7 @@ def build_cases(
             transport=transport,  # type: ignore[arg-type]
             payload_size=payload_size,
             num_buffers=num_buffers,
+            trace=trace,
         )
         for api in apis
         for transport in transports
@@ -169,18 +176,36 @@ async def _async_roundtrip(
     payload = bytes(case.payload_size)
 
     async with ez.GraphContext(graph_address, auto_start=False) as ctx:
+        process = ProcessControlClient(graph_address)
+        await process.connect()
+        process._trace_push_interval_s = 60.0
         pub = await ctx.publisher(topic, **_publisher_transport_kwargs(case, graph_address[0]))
         sub = await ctx.subscriber(topic)
+        try:
+            if case.trace:
+                await process.register([TRACE_UNIT_ADDRESS])
+                await ctx.process_set_profiling_trace(
+                    TRACE_UNIT_ADDRESS,
+                    ProfilingTraceControl(
+                        enabled=True,
+                        sample_mod=1,
+                        publisher_topics=[topic],
+                        subscriber_topics=[topic],
+                        metrics=DEFAULT_TRACE_METRICS,
+                    ),
+                )
 
-        for _ in range(warmup):
-            await pub.broadcast(payload)
-            await sub.recv()
+            for _ in range(warmup):
+                await pub.broadcast(payload)
+                await sub.recv()
 
-        start = time.perf_counter()
-        for _ in range(count):
-            await pub.broadcast(payload)
-            await sub.recv()
-        return time.perf_counter() - start
+            start = time.perf_counter()
+            for _ in range(count):
+                await pub.broadcast(payload)
+                await sub.recv()
+            return time.perf_counter() - start
+        finally:
+            await process.close()
 
 
 def _sync_roundtrip(
@@ -194,18 +219,38 @@ def _sync_roundtrip(
     payload = bytes(case.payload_size)
 
     with ez.sync.init(graph_address, auto_start=False) as ctx:
+        process = ProcessControlClient(graph_address)
+        asyncio.run(process.connect())
+        process._trace_push_interval_s = 60.0
         pub = ctx.create_publisher(topic, **_publisher_transport_kwargs(case, graph_address[0]))
         sub = ctx.create_subscription(topic)
+        try:
+            if case.trace:
+                asyncio.run(process.register([TRACE_UNIT_ADDRESS]))
+                asyncio.run(
+                    ctx._graph_context.process_set_profiling_trace(
+                        TRACE_UNIT_ADDRESS,
+                        ProfilingTraceControl(
+                            enabled=True,
+                            sample_mod=1,
+                            publisher_topics=[topic],
+                            subscriber_topics=[topic],
+                            metrics=DEFAULT_TRACE_METRICS,
+                        ),
+                    )
+                )
 
-        for _ in range(warmup):
-            pub.publish(payload)
-            sub.recv()
+            for _ in range(warmup):
+                pub.publish(payload)
+                sub.recv()
 
-        start = time.perf_counter()
-        for _ in range(count):
-            pub.publish(payload)
-            sub.recv()
-        return time.perf_counter() - start
+            start = time.perf_counter()
+            for _ in range(count):
+                pub.publish(payload)
+                sub.recv()
+            return time.perf_counter() - start
+        finally:
+            asyncio.run(process.close())
 
 
 def run_hotpath_case(
@@ -254,11 +299,12 @@ def run_hotpath_suite(
     transports: list[str],
     payload_sizes: list[int],
     num_buffers: int,
+    trace: bool,
     seed: int,
     quiet: bool,
 ) -> HotPathSuiteResult:
     rng = random.Random(seed)
-    cases = build_cases(apis, transports, payload_sizes, num_buffers)
+    cases = build_cases(apis, transports, payload_sizes, num_buffers, trace=trace)
     rng.shuffle(cases)
 
     graph_server = GraphServer()
@@ -311,6 +357,7 @@ def perf_hotpath(
     transports: list[str],
     payload_sizes: list[int],
     num_buffers: int,
+    trace: bool,
     seed: int,
     json_out: Path | None,
     quiet: bool,
@@ -323,6 +370,7 @@ def perf_hotpath(
         transports=transports,
         payload_sizes=payload_sizes,
         num_buffers=num_buffers,
+        trace=trace,
         seed=seed,
         quiet=quiet,
     )
@@ -330,7 +378,7 @@ def perf_hotpath(
     print("Hot-path roundtrip benchmark")
     print(
         f"count={count}, warmup={warmup}, samples={samples}, "
-        f"payload_sizes={payload_sizes}, transports={transports}, apis={apis}"
+        f"payload_sizes={payload_sizes}, transports={transports}, apis={apis}, trace={trace}"
     )
     for case_result in result.results:
         print(_format_case_result(case_result))
@@ -391,6 +439,11 @@ def setup_hotpath_cmdline(subparsers: argparse._SubParsersAction) -> None:
         help="publisher buffers (default = 1)",
     )
     p_hotpath.add_argument(
+        "--trace",
+        action="store_true",
+        help="enable publisher trace bookkeeping during the benchmark",
+    )
+    p_hotpath.add_argument(
         "--seed",
         type=int,
         default=0,
@@ -416,6 +469,7 @@ def setup_hotpath_cmdline(subparsers: argparse._SubParsersAction) -> None:
             transports=ns.transports,
             payload_sizes=ns.payload_sizes,
             num_buffers=ns.num_buffers,
+            trace=ns.trace,
             seed=ns.seed,
             json_out=ns.json_out,
             quiet=ns.quiet,

--- a/tests/test_perf_ab.py
+++ b/tests/test_perf_ab.py
@@ -28,12 +28,14 @@ def test_build_hotpath_command_contains_expected_args(tmp_path):
         apis=["async", "sync"],
         num_buffers=2,
         quiet=True,
+        trace=True,
     )
 
     assert cmd[:3] == ["/tmp/shared-python", "-m", "ezmsg.util.perf.hotpath"]
     assert "--count" in cmd
     assert "--payload-sizes" in cmd
     assert "--quiet" in cmd
+    assert "--trace" in cmd
 
 
 def test_parse_env_assignments_merges_repeatable_values():

--- a/tests/test_perf_hotpath.py
+++ b/tests/test_perf_hotpath.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from ezmsg.core.graphcontext import GraphContext

--- a/tests/test_perf_hotpath.py
+++ b/tests/test_perf_hotpath.py
@@ -1,8 +1,11 @@
 import pytest
 
+from ezmsg.core.graphcontext import GraphContext
+from ezmsg.core.processclient import ProcessControlClient
 from ezmsg.util.perf.hotpath import HotPathCase, build_cases, run_hotpath_case
 
 from ezmsg.core.graphserver import GraphServer
+from ezmsg.core.graphmeta import ProfilingTraceControl
 
 
 def test_build_cases_are_sorted_by_case_id():
@@ -13,8 +16,12 @@ def test_build_cases_are_sorted_by_case_id():
         num_buffers=1,
     )
     assert [case.case_id for case in cases] == sorted(case.case_id for case in cases)
-    assert "async/shm/payload=64/buffers=1" in {case.case_id for case in cases}
-    assert "async/local/payload=64/buffers=1" in {case.case_id for case in cases}
+    assert "async/shm/payload=64/buffers=1/trace=false" in {
+        case.case_id for case in cases
+    }
+    assert "async/local/payload=64/buffers=1/trace=false" in {
+        case.case_id for case in cases
+    }
 
 
 def test_run_hotpath_case_smoke():
@@ -39,7 +46,103 @@ def test_run_hotpath_case_smoke():
     finally:
         server.stop()
 
-    assert result.case.case_id == "sync/tcp/payload=64/buffers=1"
+    assert result.case.case_id == "sync/tcp/payload=64/buffers=1/trace=false"
     assert len(result.samples_seconds) == 2
     assert all(sample > 0 for sample in result.samples_seconds)
     assert result.summary.us_per_message_median > 0
+
+
+def test_run_hotpath_case_trace_smoke():
+    server = GraphServer()
+    try:
+        server.start(("127.0.0.1", 0))
+    except PermissionError:
+        pytest.skip("Local socket binding is unavailable in this environment")
+    try:
+        result = run_hotpath_case(
+            HotPathCase(
+                api="async",
+                transport="local",
+                payload_size=64,
+                num_buffers=1,
+                trace=True,
+            ),
+            count=8,
+            warmup=2,
+            samples=1,
+            graph_address=server.address,
+        )
+    finally:
+        server.stop()
+
+    assert result.case.case_id == "async/local/payload=64/buffers=1/trace=true"
+    assert len(result.samples_seconds) == 1
+    assert result.samples_seconds[0] > 0
+
+
+def test_build_cases_can_enable_trace_mode():
+    cases = build_cases(
+        apis=["async"],
+        transports=["local"],
+        payload_sizes=[64],
+        num_buffers=1,
+        trace=True,
+    )
+
+    assert len(cases) == 1
+    assert cases[0].trace is True
+    assert cases[0].case_id == "async/local/payload=64/buffers=1/trace=true"
+
+
+@pytest.mark.asyncio
+async def test_trace_profile_matches_dashboard_metrics():
+    server = GraphServer()
+    try:
+        server.start(("127.0.0.1", 0))
+    except PermissionError:
+        pytest.skip("Local socket binding is unavailable in this environment")
+
+    async with GraphContext(server.address, auto_start=False) as ctx:
+        process = ProcessControlClient(server.address)
+        await process.connect()
+        process._trace_push_interval_s = 60.0
+        await process.register(["EZMSG/PERF/HOTPATH"])
+
+        topic = "/EZMSG/PERF/HOTPATH/TEST"
+        pub = await ctx.publisher(topic)
+        sub = await ctx.subscriber(topic)
+
+        try:
+            response = await ctx.process_set_profiling_trace(
+                "EZMSG/PERF/HOTPATH",
+                ProfilingTraceControl(
+                    enabled=True,
+                    sample_mod=1,
+                    publisher_topics=[topic],
+                    subscriber_topics=[topic],
+                    metrics=["publish_delta_ns", "lease_time_ns", "user_span_ns"],
+                ),
+                timeout=1.0,
+            )
+            assert response.ok
+
+            await pub.broadcast(b"1234")
+            async with sub.recv_zero_copy() as _msg:
+                span_start_ns = sub.begin_profile()
+                try:
+                    await asyncio.sleep(0)
+                finally:
+                    sub.end_profile(span_start_ns, "taskA")
+
+            batch = await ctx.process_profiling_trace_batch(
+                "EZMSG/PERF/HOTPATH", max_samples=100, timeout=1.0
+            )
+        finally:
+            await process.close()
+            server.stop()
+
+    assert {sample.metric for sample in batch.samples} >= {
+        "publish_delta_ns",
+        "lease_time_ns",
+        "user_span_ns",
+    }


### PR DESCRIPTION
## Summary

Adds trace mode to `ezmsg perf hotpath` so the benchmark can measure hot-path latency with profiling trace instrumentation enabled.

## What changed

- Added `--trace` to `ezmsg perf hotpath`
- Configured trace mode to mirror the dashboard trace profile:
  - `sample_mod=1`
  - `publisher_topics=[topic]`
  - `subscriber_topics=[topic]`
  - `metrics=["publish_delta_ns", "lease_time_ns", "user_span_ns"]`
- Routed trace control through a `ProcessControlClient` / process unit address instead of incorrectly targeting a publisher object
- Included the trace setting in benchmark case IDs and output (`/trace=true|false`)
- Updated the perf AB helper so it can invoke hotpath with trace enabled
- Added targeted tests for:
  - trace-enabled case construction
  - trace-enabled hotpath smoke coverage
  - dashboard-aligned trace metric coverage

## Notes

- This benchmark measures the hot-path cost of trace instrumentation itself.
- It does **not** fully model downstream dashboard/UI overhead or slow trace-consumer effects, because trace samples are buffered in bounded queues and dropped rather than backpressuring publishers.
- Local transport shows the clearest regression because tracing overhead is a larger fraction of total roundtrip cost there than it is for SHM/TCP.

## Validation

- Ran: `uv run pytest tests/test_perf_hotpath.py tests/test_perf_ab.py -q`
- Result: `6 passed, 3 skipped`
