### PR TITLE
Feature: Raise file descriptor limit during execution

### DIFF
--- a/src/ezmsg/core/backend.py
+++ b/src/ezmsg/core/backend.py
@@ -67,7 +67,7 @@ from .backendprocess import (
     new_threaded_event_loop,
 )
 
-from .util import either_dict_or_kwargs
+from .util import either_dict_or_kwargs, elevated_fd_limit
 
 logger = logging.getLogger("ezmsg")
 
@@ -626,23 +626,24 @@ class GraphRunner:
             raise RuntimeError("GraphRunner cannot be restarted")
         if self._force_single_process:
             raise ValueError("force_single_process is only supported with run_blocking")
-        if not self._initialize(force_single_process=False, wait_for_ready=True):
-            return
+        with elevated_fd_limit():
+            if not self._initialize(force_single_process=False, wait_for_ready=True):
+                return
 
-        self._start_processes(self.processes)
+            self._start_processes(self.processes)
 
-        if self._start_participant and self._execution_context is not None:
-            try:
-                self._execution_context.start_barrier.wait()
-            except BrokenBarrierError as err:
-                self._execution_context.term_ev.set()
-                self._join_spawned_processes()
-                self._cleanup()
-                self._stopped = True
-                raise GraphRunnerStartError(
-                    "GraphRunner failed to start. One or more processes exited before "
-                    "reaching the start barrier; check logs for earlier exceptions."
-                ) from err
+            if self._start_participant and self._execution_context is not None:
+                try:
+                    self._execution_context.start_barrier.wait()
+                except BrokenBarrierError as err:
+                    self._execution_context.term_ev.set()
+                    self._join_spawned_processes()
+                    self._cleanup()
+                    self._stopped = True
+                    raise GraphRunnerStartError(
+                        "GraphRunner failed to start. One or more processes exited before "
+                        "reaching the start barrier; check logs for earlier exceptions."
+                    ) from err
         self._started = True
         if self._stopped:
             self._started = False
@@ -663,11 +664,12 @@ class GraphRunner:
             raise RuntimeError("GraphRunner is already running")
         if self._stopped:
             raise RuntimeError("GraphRunner cannot be restarted")
-        if not self._initialize(
-            force_single_process=self._force_single_process, wait_for_ready=False
-        ):
-            return
-        self._run_main_process()
+        with elevated_fd_limit():
+            if not self._initialize(
+                force_single_process=self._force_single_process, wait_for_ready=False
+            ):
+                return
+            self._run_main_process()
 
     def _initialize(self, force_single_process: bool, wait_for_ready: bool) -> bool:
         os.environ["EZMSG_PROFILER"] = self._profiler_log_name or "ezprofiler.log"

--- a/src/ezmsg/core/graphserver.py
+++ b/src/ezmsg/core/graphserver.py
@@ -62,6 +62,7 @@ from .netprotocol import (
     DEFAULT_HOST,
 )
 from .shm import SHMContext, SHMInfo
+from .util import elevated_fd_limit
 
 logger = logging.getLogger("ezmsg")
 PERSISTENT_EDGE_OWNER = None
@@ -1801,7 +1802,8 @@ class GraphService:
 
     def create_server(self) -> GraphServer:
         server = GraphServer(name="GraphServer")
-        server.start(self._address)
+        with elevated_fd_limit():
+            server.start(self._address)
         self._address = server.address
         return server
 

--- a/src/ezmsg/core/util.py
+++ b/src/ezmsg/core/util.py
@@ -1,5 +1,19 @@
+import contextlib
+import logging
+import os
 from collections.abc import Mapping
 import typing
+
+
+logger = logging.getLogger("ezmsg")
+
+EZMSG_FD_LIMIT_ENV = "EZMSG_FD_LIMIT"
+EZMSG_FD_LIMIT_DEFAULT = 100_000
+
+try:
+    import resource
+except ImportError:
+    resource = None  # type: ignore[assignment]
 
 
 T = typing.TypeVar("T")
@@ -56,3 +70,57 @@ def either_dict_or_kwargs(
             f"cannot specify both keyword and positional arguments to .{func_name}"
         )
     return pos_kwargs
+
+
+def _configured_fd_limit() -> int:
+    value = os.environ.get(EZMSG_FD_LIMIT_ENV, str(EZMSG_FD_LIMIT_DEFAULT))
+    try:
+        limit = int(value)
+    except ValueError:
+        logger.warning(
+            f"Invalid {EZMSG_FD_LIMIT_ENV}={value!r}; using default {EZMSG_FD_LIMIT_DEFAULT}"
+        )
+        return EZMSG_FD_LIMIT_DEFAULT
+    return max(1, limit)
+
+
+def _fd_limit_supported() -> bool:
+    return resource is not None and hasattr(resource, "RLIMIT_NOFILE")
+
+
+@contextlib.contextmanager
+def elevated_fd_limit(limit: int | None = None):
+    if not _fd_limit_supported():
+        yield
+        return
+
+    assert resource is not None
+    target = _configured_fd_limit() if limit is None else max(1, limit)
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    desired_limit = min(target, hard_limit)
+
+    if desired_limit <= soft_limit:
+        yield
+        return
+
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (desired_limit, hard_limit))
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            f"Unable to raise RLIMIT_NOFILE from {soft_limit} to {desired_limit}: {exc}"
+        )
+        yield
+        return
+
+    logger.info(
+        f"Raised RLIMIT_NOFILE soft limit from {soft_limit} to {desired_limit}"
+    )
+    try:
+        yield
+    finally:
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                f"Unable to restore RLIMIT_NOFILE soft limit to {soft_limit}: {exc}"
+            )

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 
 from ezmsg.core.graphserver import GraphService
+from ezmsg.core import util
 
 
 @pytest.mark.asyncio
@@ -97,6 +98,111 @@ async def test_shutdown() -> None:
     with pytest.raises(BufferError):
         with attach_shm.buffer(0) as mem:
             assert content == mem[0 : len(content)]
+
+
+@pytest.mark.skipif(
+    util.resource is None or not hasattr(util.resource, "RLIMIT_NOFILE"),
+    reason="RLIMIT_NOFILE unsupported on this platform",
+)
+def test_elevated_fd_limit_raises_and_restores(monkeypatch):
+    calls = []
+
+    class FakeResource:
+        RLIMIT_NOFILE = object()
+
+        def __init__(self):
+            self.soft = 256
+            self.hard = 4096
+
+        def getrlimit(self, which):
+            assert which is self.RLIMIT_NOFILE
+            return (self.soft, self.hard)
+
+        def setrlimit(self, which, limits):
+            assert which is self.RLIMIT_NOFILE
+            calls.append(limits)
+            self.soft, self.hard = limits
+
+    fake = FakeResource()
+    monkeypatch.setattr(util, "resource", fake)
+    monkeypatch.setenv("EZMSG_FD_LIMIT", "1024")
+
+    with util.elevated_fd_limit():
+        assert fake.soft == 1024
+
+    assert fake.soft == 256
+    assert calls == [(1024, 4096), (256, 4096)]
+
+
+@pytest.mark.skipif(
+    util.resource is None or not hasattr(util.resource, "RLIMIT_NOFILE"),
+    reason="RLIMIT_NOFILE unsupported on this platform",
+)
+def test_elevated_fd_limit_uses_safe_config(monkeypatch):
+    calls = []
+
+    class FakeResource:
+        RLIMIT_NOFILE = object()
+
+        def __init__(self):
+            self.soft = 512
+            self.hard = 2048
+
+        def getrlimit(self, which):
+            return (self.soft, self.hard)
+
+        def setrlimit(self, which, limits):
+            calls.append(limits)
+            self.soft, self.hard = limits
+
+    fake = FakeResource()
+    monkeypatch.setattr(util, "resource", fake)
+    monkeypatch.setenv("EZMSG_FD_LIMIT", "bogus")
+
+    with util.elevated_fd_limit():
+        assert fake.soft == 2048
+
+    assert calls == [(2048, 2048), (512, 2048)]
+
+
+def test_runtime_entrypoints_wrap_fd_limit(monkeypatch):
+    from ezmsg.core.backend import GraphRunner
+
+    calls = []
+
+    class DummyContext:
+        def __enter__(self):
+            calls.append("enter")
+
+        def __exit__(self, exc_type, exc, tb):
+            calls.append("exit")
+
+    monkeypatch.setattr("ezmsg.core.graphserver.elevated_fd_limit", lambda: DummyContext())
+    monkeypatch.setattr("ezmsg.core.backend.elevated_fd_limit", lambda: DummyContext())
+
+    class DummyServer:
+        address = ("127.0.0.1", 1234)
+
+        def __init__(self, name):
+            assert name == "GraphServer"
+
+        def start(self, address):
+            return None
+
+    monkeypatch.setattr("ezmsg.core.graphserver.GraphServer", DummyServer)
+
+    service = GraphService()
+    service.create_server()
+
+    runner = GraphRunner(components={"SYSTEM": object()})
+    monkeypatch.setattr(runner, "_initialize", lambda **kwargs: False)
+    runner.start()
+
+    runner = GraphRunner(components={"SYSTEM": object()})
+    monkeypatch.setattr(runner, "_initialize", lambda **kwargs: False)
+    runner.run_blocking()
+
+    assert calls == ["enter", "exit", "enter", "exit", "enter", "exit"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #247 

## Summary

Raise the soft file-descriptor limit at ezmsg runtime entrypoints so moderately large systems are less likely to fail under low default `ulimit` settings.

This change is intentionally narrow:
- only applies at execution entrypoints,
- is best-effort and platform-safe,
- restores the original limit after execution completes.

## Motivation

`ezmsg` can legitimately consume a large number of file descriptors through sockets, shared memory handles, and related resources. This can result in `OSError: [Errno 24] Too many open files` followed by a system crash. On systems with low default limits (for example `256` or `1024`), moderately sophisticated graphs can exhaust the available descriptors and fail even though the operating system can support a much higher per-process limit.

Rather than changing process limits globally or at import time, this change raises `RLIMIT_NOFILE` only where ezmsg actually starts execution.

## Changes

- Added `elevated_fd_limit()` in `src/ezmsg/core/util.py`
- Applied the scoped FD-limit bump in:
  - `GraphRunner.start()`
  - `GraphRunner.run_blocking()`
  - `GraphService.create_server()`
- Added support for configuring the target soft limit via `EZMSG_FD_LIMIT`
- Default target soft limit is `100_000`
- Removed the separate FD-limit test module and folded coverage into existing runtime/resource tests

## Behavior

- Uses `resource.setrlimit(RLIMIT_NOFILE, ...)` when supported
- No-ops on platforms where `resource` / `RLIMIT_NOFILE` is unavailable
- Clamps the requested soft limit to the current hard limit
- Logs a warning and continues if the limit cannot be raised
- Restores the original soft limit on exit

## Why these entrypoints

These are the places where ezmsg actually begins execution and/or starts child processes:

- `GraphRunner.start()`
- `GraphRunner.run_blocking()`
- `GraphService.create_server()`

That keeps the behavior narrowly scoped while ensuring child processes inherit the raised limit when they are created.

## Testing

Validated with focused tests covering:
- raise + restore behavior,
- invalid env / safe fallback behavior,
- entrypoint wrapping behavior.

Commands run:
- `uv run pytest tests/test_shm.py -q -k 'elevated_fd_limit or runtime_entrypoints_wrap_fd_limit'`
- `uv run pytest tests/test_dashboard_commands.py -q`

