### PR TITLE
Fix: Channel failure on shm resize due to CacheMiss

### DIFF
--- a/src/ezmsg/core/messagechannel.py
+++ b/src/ezmsg/core/messagechannel.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager, suppress
 from .shm import SHMContext
 from .messagemarshal import MessageMarshal
 from .backpressure import Backpressure
-from .messagecache import MessageCache
+from .messagecache import MessageCache, CacheMiss
 from .graphserver import GraphService
 from .netprotocol import (
     Command,
@@ -277,17 +277,42 @@ class Channel:
                                 self._graph_address
                             ).attach_shm(shm_name)
                         except ValueError:
-                            logger.info(
-                                "Invalid SHM received from publisher; may be dead"
+                            logger.warning(
+                                "Channel %s received stale SHM %s for publisher %s; waiting for next valid SHM",
+                                self.id,
+                                shm_name,
+                                self.pub_id,
                             )
-                            raise
+                            self.shm = None
 
-                        for id in shm_entries:
-                            self.cache.put_from_mem(self.shm[id % self.num_buffers])
+                        if self.shm is not None:
+                            for id in shm_entries:
+                                shm_buf = self.shm[id % self.num_buffers]
+                                if MessageMarshal.msg_id(shm_buf) == id:
+                                    self.cache.put_from_mem(shm_buf)
 
-                    assert self.shm is not None
-                    assert MessageMarshal.msg_id(self.shm[buf_idx]) == msg_id
-                    self.cache.put_from_mem(self.shm[buf_idx])
+                    if self.shm is None:
+                        logger.warning(
+                            "Channel %s dropping message %s from publisher %s because its SHM generation is stale",
+                            self.id,
+                            msg_id,
+                            self.pub_id,
+                        )
+                        self._release_backpressure(msg_id, self.id)
+                        continue
+
+                    shm_buf = self.shm[buf_idx]
+                    if MessageMarshal.msg_id(shm_buf) != msg_id:
+                        logger.warning(
+                            "Channel %s skipping stale SHM contents for message %s from publisher %s; will use next valid SHM generation",
+                            self.id,
+                            msg_id,
+                            self.pub_id,
+                        )
+                        self._release_backpressure(msg_id, self.id)
+                        continue
+
+                    self.cache.put_from_mem(shm_buf)
 
                 elif msg == Command.TX_TCP.value:
                     channel_kind = ProfileChannelType.TCP
@@ -407,7 +432,15 @@ class Channel:
         buf_idx = msg_id % self.num_buffers
         self.backpressure.free(client_id, buf_idx)
         if self.backpressure.buffers[buf_idx].is_empty:
-            self.cache.release(msg_id)
+            try:
+                self.cache.release(msg_id)
+            except CacheMiss:
+                logger.debug(
+                    "Channel %s observed cache miss while releasing msg_id=%s from publisher %s; continuing backpressure release",
+                    self.id,
+                    msg_id,
+                    self.pub_id,
+                )
 
             # If pub is in same process as this channel, avoid TCP
             if self._local_backpressure is not None:

--- a/src/ezmsg/core/messagechannel.py
+++ b/src/ezmsg/core/messagechannel.py
@@ -4,7 +4,7 @@ import typing
 import logging
 
 from uuid import UUID
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 
 from .shm import SHMContext
 from .messagemarshal import MessageMarshal
@@ -24,6 +24,10 @@ from .netprotocol import (
 from .graphmeta import ProfileChannelType
 
 logger = logging.getLogger("ezmsg")
+
+
+class ChannelError(RuntimeError):
+    """Raised when a channel cannot safely process publisher traffic."""
 
 
 class LeakyQueue(asyncio.Queue[typing.Tuple[UUID, int]]):
@@ -266,34 +270,38 @@ class Channel:
                     channel_kind = ProfileChannelType.SHM
                     shm_name = await read_str(reader)
 
-                    if self.shm is not None and self.shm.name != shm_name:
-                        shm_entries = self.cache.keys()
-                        self.cache.clear()
-                        self.shm.close()
-                        await self.shm.wait_closed()
+                    if self.shm is None or self.shm.name != shm_name:
+                        await self._reattach_shm(shm_name)
 
-                        try:
-                            self.shm = await GraphService(
-                                self._graph_address
-                            ).attach_shm(shm_name)
-                        except ValueError:
-                            logger.info(
-                                "Invalid SHM received from publisher; may be dead"
-                            )
-                            raise
+                    if self.shm is None:
+                        raise ChannelError(
+                            f"channel {self.id} has no SHM attached for {shm_name}"
+                        )
 
-                        for id in shm_entries:
-                            self.cache.put_from_mem(self.shm[id % self.num_buffers])
+                    try:
+                        shm_buf = self.shm[buf_idx]
+                    except BufferError as exc:
+                        raise ChannelError(
+                            f"channel {self.id} lost SHM {shm_name} while reading {msg_id=}"
+                        ) from exc
 
-                    assert self.shm is not None
-                    assert MessageMarshal.msg_id(self.shm[buf_idx]) == msg_id
-                    self.cache.put_from_mem(self.shm[buf_idx])
+                    if MessageMarshal.msg_id(shm_buf) != msg_id:
+                        raise ChannelError(
+                            f"channel {self.id} saw mismatched SHM contents in {shm_name}: "
+                            f"expected {msg_id}, got {MessageMarshal.msg_id(shm_buf)}"
+                        )
+
+                    self.cache.put_from_mem(shm_buf)
 
                 elif msg == Command.TX_TCP.value:
                     channel_kind = ProfileChannelType.TCP
                     buf_size = await read_int(reader)
                     obj_bytes = await reader.readexactly(buf_size)
-                    assert MessageMarshal.msg_id(obj_bytes) == msg_id
+                    if MessageMarshal.msg_id(obj_bytes) != msg_id:
+                        raise ChannelError(
+                            f"channel {self.id} saw mismatched TCP contents: "
+                            f"expected {msg_id}, got {MessageMarshal.msg_id(obj_bytes)}"
+                        )
                     self.cache.put_from_mem(memoryview(obj_bytes).toreadonly())
 
                 else:
@@ -308,6 +316,12 @@ class Channel:
 
         except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
             logger.debug(f"connection fail: channel:{self.id} - pub:{self.pub_id}")
+        except (ChannelError, FileNotFoundError):
+            logger.exception(
+                "Publisher connection failed for channel %s from publisher %s",
+                self.id,
+                self.pub_id,
+            )
 
         finally:
             self.cache.clear()
@@ -317,6 +331,43 @@ class Channel:
             await close_stream_writer(self._pub_writer)
 
             logger.debug(f"disconnected: channel:{self.id} -> pub:{self.pub_id}")
+
+    async def _reattach_shm(self, shm_name: str) -> None:
+        cached_msg_ids = self.cache.keys()
+        self.cache.clear()
+
+        prior_shm = self.shm
+        self.shm = None
+        if prior_shm is not None:
+            prior_shm.close()
+            await prior_shm.wait_closed()
+
+        try:
+            self.shm = await GraphService(self._graph_address).attach_shm(shm_name)
+        except (ValueError, FileNotFoundError) as exc:
+            raise ChannelError(
+                f"channel {self.id} failed to attach SHM {shm_name}"
+            ) from exc
+
+        for cached_msg_id in cached_msg_ids:
+            cached_buf_idx = cached_msg_id % self.num_buffers
+            try:
+                cached_mem = self.shm[cached_buf_idx]
+            except BufferError as exc:
+                raise ChannelError(
+                    f"channel {self.id} lost SHM {shm_name} while restoring cache"
+                ) from exc
+
+            if MessageMarshal.msg_id(cached_mem) != cached_msg_id:
+                logger.warning(
+                    "Dropping stale cached message %s during SHM switch to %s on channel %s",
+                    cached_msg_id,
+                    shm_name,
+                    self.id,
+                )
+                continue
+
+            self.cache.put_from_mem(cached_mem)
 
     def _set_channel_kind(self, kind: ProfileChannelType) -> None:
         if self._channel_kind == ProfileChannelType.UNKNOWN:

--- a/src/ezmsg/core/messagechannel.py
+++ b/src/ezmsg/core/messagechannel.py
@@ -4,7 +4,7 @@ import typing
 import logging
 
 from uuid import UUID
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 from .shm import SHMContext
 from .messagemarshal import MessageMarshal
@@ -24,10 +24,6 @@ from .netprotocol import (
 from .graphmeta import ProfileChannelType
 
 logger = logging.getLogger("ezmsg")
-
-
-class ChannelError(RuntimeError):
-    """Raised when a channel cannot safely process publisher traffic."""
 
 
 class LeakyQueue(asyncio.Queue[typing.Tuple[UUID, int]]):
@@ -270,38 +266,34 @@ class Channel:
                     channel_kind = ProfileChannelType.SHM
                     shm_name = await read_str(reader)
 
-                    if self.shm is None or self.shm.name != shm_name:
-                        await self._reattach_shm(shm_name)
+                    if self.shm is not None and self.shm.name != shm_name:
+                        shm_entries = self.cache.keys()
+                        self.cache.clear()
+                        self.shm.close()
+                        await self.shm.wait_closed()
 
-                    if self.shm is None:
-                        raise ChannelError(
-                            f"channel {self.id} has no SHM attached for {shm_name}"
-                        )
+                        try:
+                            self.shm = await GraphService(
+                                self._graph_address
+                            ).attach_shm(shm_name)
+                        except ValueError:
+                            logger.info(
+                                "Invalid SHM received from publisher; may be dead"
+                            )
+                            raise
 
-                    try:
-                        shm_buf = self.shm[buf_idx]
-                    except BufferError as exc:
-                        raise ChannelError(
-                            f"channel {self.id} lost SHM {shm_name} while reading {msg_id=}"
-                        ) from exc
+                        for id in shm_entries:
+                            self.cache.put_from_mem(self.shm[id % self.num_buffers])
 
-                    if MessageMarshal.msg_id(shm_buf) != msg_id:
-                        raise ChannelError(
-                            f"channel {self.id} saw mismatched SHM contents in {shm_name}: "
-                            f"expected {msg_id}, got {MessageMarshal.msg_id(shm_buf)}"
-                        )
-
-                    self.cache.put_from_mem(shm_buf)
+                    assert self.shm is not None
+                    assert MessageMarshal.msg_id(self.shm[buf_idx]) == msg_id
+                    self.cache.put_from_mem(self.shm[buf_idx])
 
                 elif msg == Command.TX_TCP.value:
                     channel_kind = ProfileChannelType.TCP
                     buf_size = await read_int(reader)
                     obj_bytes = await reader.readexactly(buf_size)
-                    if MessageMarshal.msg_id(obj_bytes) != msg_id:
-                        raise ChannelError(
-                            f"channel {self.id} saw mismatched TCP contents: "
-                            f"expected {msg_id}, got {MessageMarshal.msg_id(obj_bytes)}"
-                        )
+                    assert MessageMarshal.msg_id(obj_bytes) == msg_id
                     self.cache.put_from_mem(memoryview(obj_bytes).toreadonly())
 
                 else:
@@ -316,12 +308,6 @@ class Channel:
 
         except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
             logger.debug(f"connection fail: channel:{self.id} - pub:{self.pub_id}")
-        except (ChannelError, FileNotFoundError):
-            logger.exception(
-                "Publisher connection failed for channel %s from publisher %s",
-                self.id,
-                self.pub_id,
-            )
 
         finally:
             self.cache.clear()
@@ -331,43 +317,6 @@ class Channel:
             await close_stream_writer(self._pub_writer)
 
             logger.debug(f"disconnected: channel:{self.id} -> pub:{self.pub_id}")
-
-    async def _reattach_shm(self, shm_name: str) -> None:
-        cached_msg_ids = self.cache.keys()
-        self.cache.clear()
-
-        prior_shm = self.shm
-        self.shm = None
-        if prior_shm is not None:
-            prior_shm.close()
-            await prior_shm.wait_closed()
-
-        try:
-            self.shm = await GraphService(self._graph_address).attach_shm(shm_name)
-        except (ValueError, FileNotFoundError) as exc:
-            raise ChannelError(
-                f"channel {self.id} failed to attach SHM {shm_name}"
-            ) from exc
-
-        for cached_msg_id in cached_msg_ids:
-            cached_buf_idx = cached_msg_id % self.num_buffers
-            try:
-                cached_mem = self.shm[cached_buf_idx]
-            except BufferError as exc:
-                raise ChannelError(
-                    f"channel {self.id} lost SHM {shm_name} while restoring cache"
-                ) from exc
-
-            if MessageMarshal.msg_id(cached_mem) != cached_msg_id:
-                logger.warning(
-                    "Dropping stale cached message %s during SHM switch to %s on channel %s",
-                    cached_msg_id,
-                    shm_name,
-                    self.id,
-                )
-                continue
-
-            self.cache.put_from_mem(cached_mem)
 
     def _set_channel_kind(self, kind: ProfileChannelType) -> None:
         if self._channel_kind == ProfileChannelType.UNKNOWN:

--- a/tests/shm_resize_race_runner.py
+++ b/tests/shm_resize_race_runner.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+
+import ezmsg.core as ez
+
+INITIAL_SHM_SIZE = 64
+NUM_MSGS = 4
+SUBSCRIBER_DELAY_S = 0.001
+READY_TOKEN = "READY"
+DONE_TOKEN = "DONE"
+
+
+@dataclass
+class BurstMessage:
+    seq: int
+    payload: bytes
+    created_at: float
+
+
+class BurstyPublisher(ez.Unit):
+    OUTPUT = ez.OutputStream(
+        BurstMessage,
+        num_buffers=2,
+        buf_size=INITIAL_SHM_SIZE,
+        force_tcp=False,
+        allow_local=False,
+    )
+
+    @ez.publisher(OUTPUT)
+    async def pump(self):
+        cur_size = INITIAL_SHM_SIZE
+        print(READY_TOKEN, flush=True)
+        for itr in range(NUM_MSGS):
+            cur_size *= 3
+            yield self.OUTPUT, BurstMessage(
+                seq=itr,
+                payload=bytes(cur_size),
+                created_at=time.time(),
+            )
+
+
+class SubscriberState(ez.State):
+    cur_msg: int = 0
+
+
+class Subscriber(ez.Unit):
+    INPUT = ez.InputStream(BurstMessage)
+    STATE = SubscriberState
+
+    @ez.subscriber(INPUT)
+    async def on_message(self, msg: BurstMessage) -> None:
+        await asyncio.sleep(SUBSCRIBER_DELAY_S)
+        self.STATE.cur_msg += 1
+        if self.STATE.cur_msg == NUM_MSGS:
+            print(DONE_TOKEN, flush=True)
+            raise ez.NormalTermination
+
+
+class ReproSystem(ez.Collection):
+    PUB = BurstyPublisher()
+    SUB = Subscriber()
+
+    def network(self) -> ez.NetworkDefinition:
+        return ((self.PUB.OUTPUT, self.SUB.INPUT),)
+
+    def process_components(self) -> list[ez.Component]:
+        return [self.PUB, self.SUB]
+
+
+if __name__ == "__main__":
+    ez.run(SYSTEM=ReproSystem())

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,12 +1,14 @@
 import asyncio
 from uuid import uuid4
+from unittest.mock import patch
 
 import pytest
 
-from ezmsg.core.messagechannel import Channel
+from ezmsg.core.messagechannel import Channel, ChannelError
 from ezmsg.core.messagecache import CacheMiss
 from ezmsg.core.netprotocol import Command, uint64_to_bytes
 from ezmsg.core.backpressure import Backpressure
+from ezmsg.core.messagemarshal import MessageMarshal
 
 
 class DummyWriter:
@@ -91,3 +93,70 @@ def test_channel_put_local_requires_local_backpressure():
     channel = Channel(uuid4(), uuid4(), 1, None, None, Channel._SENTINEL)
     with pytest.raises(ValueError):
         channel.put_local(1, "no pub")
+
+
+class FakeSHM:
+    def __init__(self, name: str, buffers: dict[int, memoryview] | None = None):
+        self.name = name
+        self._buffers = buffers or {}
+        self.closed = False
+        self.waited = False
+
+    def __getitem__(self, idx: int) -> memoryview:
+        return self._buffers[idx]
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited = True
+
+
+def _marshal_message(msg_id: int, obj: object) -> memoryview:
+    with MessageMarshal.serialize(msg_id, obj) as (size, header, buffers):
+        raw = bytearray(size + 1)
+        mem = memoryview(raw)
+        MessageMarshal._write(mem, header, buffers)
+        return mem.toreadonly()
+
+
+@pytest.mark.asyncio
+async def test_channel_reattach_shm_drops_stale_cached_messages():
+    old_shm = FakeSHM("old")
+    channel = Channel(uuid4(), uuid4(), 2, old_shm, ("127.0.0.1", 0), Channel._SENTINEL)
+
+    channel.cache.put_local("cached", 1)
+    new_shm = FakeSHM("new", {1: _marshal_message(3, "fresh")})
+
+    class FakeGraphService:
+        def __init__(self, address):
+            self.address = address
+
+        async def attach_shm(self, shm_name: str):
+            assert shm_name == "new"
+            return new_shm
+
+    with patch("ezmsg.core.messagechannel.GraphService", FakeGraphService):
+        await channel._reattach_shm("new")
+
+    assert channel.shm is new_shm
+    assert old_shm.closed is True
+    assert old_shm.waited is True
+    with pytest.raises(CacheMiss):
+        _ = channel.cache[1]
+
+
+@pytest.mark.asyncio
+async def test_channel_reattach_shm_wraps_missing_segment():
+    channel = Channel(uuid4(), uuid4(), 2, None, ("127.0.0.1", 0), Channel._SENTINEL)
+
+    class FakeGraphService:
+        def __init__(self, address):
+            self.address = address
+
+        async def attach_shm(self, shm_name: str):
+            raise FileNotFoundError(shm_name)
+
+    with patch("ezmsg.core.messagechannel.GraphService", FakeGraphService):
+        with pytest.raises(ChannelError):
+            await channel._reattach_shm("missing")

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,14 +1,12 @@
 import asyncio
 from uuid import uuid4
-from unittest.mock import patch
 
 import pytest
 
-from ezmsg.core.messagechannel import Channel, ChannelError
+from ezmsg.core.messagechannel import Channel
 from ezmsg.core.messagecache import CacheMiss
 from ezmsg.core.netprotocol import Command, uint64_to_bytes
 from ezmsg.core.backpressure import Backpressure
-from ezmsg.core.messagemarshal import MessageMarshal
 
 
 class DummyWriter:
@@ -93,70 +91,3 @@ def test_channel_put_local_requires_local_backpressure():
     channel = Channel(uuid4(), uuid4(), 1, None, None, Channel._SENTINEL)
     with pytest.raises(ValueError):
         channel.put_local(1, "no pub")
-
-
-class FakeSHM:
-    def __init__(self, name: str, buffers: dict[int, memoryview] | None = None):
-        self.name = name
-        self._buffers = buffers or {}
-        self.closed = False
-        self.waited = False
-
-    def __getitem__(self, idx: int) -> memoryview:
-        return self._buffers[idx]
-
-    def close(self) -> None:
-        self.closed = True
-
-    async def wait_closed(self) -> None:
-        self.waited = True
-
-
-def _marshal_message(msg_id: int, obj: object) -> memoryview:
-    with MessageMarshal.serialize(msg_id, obj) as (size, header, buffers):
-        raw = bytearray(size + 1)
-        mem = memoryview(raw)
-        MessageMarshal._write(mem, header, buffers)
-        return mem.toreadonly()
-
-
-@pytest.mark.asyncio
-async def test_channel_reattach_shm_drops_stale_cached_messages():
-    old_shm = FakeSHM("old")
-    channel = Channel(uuid4(), uuid4(), 2, old_shm, ("127.0.0.1", 0), Channel._SENTINEL)
-
-    channel.cache.put_local("cached", 1)
-    new_shm = FakeSHM("new", {1: _marshal_message(3, "fresh")})
-
-    class FakeGraphService:
-        def __init__(self, address):
-            self.address = address
-
-        async def attach_shm(self, shm_name: str):
-            assert shm_name == "new"
-            return new_shm
-
-    with patch("ezmsg.core.messagechannel.GraphService", FakeGraphService):
-        await channel._reattach_shm("new")
-
-    assert channel.shm is new_shm
-    assert old_shm.closed is True
-    assert old_shm.waited is True
-    with pytest.raises(CacheMiss):
-        _ = channel.cache[1]
-
-
-@pytest.mark.asyncio
-async def test_channel_reattach_shm_wraps_missing_segment():
-    channel = Channel(uuid4(), uuid4(), 2, None, ("127.0.0.1", 0), Channel._SENTINEL)
-
-    class FakeGraphService:
-        def __init__(self, address):
-            self.address = address
-
-        async def attach_shm(self, shm_name: str):
-            raise FileNotFoundError(shm_name)
-
-    with patch("ezmsg.core.messagechannel.GraphService", FakeGraphService):
-        with pytest.raises(ChannelError):
-            await channel._reattach_shm("missing")

--- a/tests/test_clean_shutdown.py
+++ b/tests/test_clean_shutdown.py
@@ -12,6 +12,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = Path(__file__).with_name("shutdown_runner.py")
 EXAMPLE_RUNNER = Path(__file__).with_name("clean_shutdown_examples_runner.py")
+SHM_RACE_RUNNER = Path(__file__).with_name("shm_resize_race_runner.py")
 
 
 def _run_process(
@@ -187,6 +188,19 @@ def _run_example_case(
     )
 
 
+def _run_shm_resize_race_case(*, timeout: float = 1.0) -> None:
+    env = os.environ.copy()
+    env.pop("EZMSG_STRICT_SHUTDOWN", None)
+    _run_process(
+        [sys.executable, "-u", str(SHM_RACE_RUNNER)],
+        env=env,
+        signals=0,
+        ready_token="READY",
+        timeout=timeout,
+        allowed_returncodes={0},
+    )
+
+
 def _sigint_returncodes() -> set[int]:
     if os.name == "nt":
         return {1, 3221225786}
@@ -223,3 +237,7 @@ def test_infinite_requires_sigint(start_method: str) -> None:
         signals=1,
         allowed_returncodes={0},
     )
+
+
+def test_shm_resize_race_repro_completes() -> None:
+    _run_shm_resize_race_case(timeout=10.0)


### PR DESCRIPTION
If a `Publisher` resizes SHM repeatedly, it can happen that the receiving `MessageChannel` either fails to lease the block before it becomes deallocated, or that the associated block is no-longer leased and is deallocated when backpressure is cleared, resulting in an uncaught `CacheMiss` exception which kills the Task servicing the connection silently.

The test case and hardening of message servicing in `MessageChannel` in this PR likely closes #253.